### PR TITLE
Improve logging of mod_loader_order

### DIFF
--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -128,7 +128,11 @@ func _init():
 	# Sort mod_load_order by the importance score of the mod
 	_get_load_order()
 
-	dev_log(str("mod_load_order -> ", JSON.print(mod_load_order, '   ')), LOG_NAME)
+	# Log mod order
+	for mod in mod_load_order: # mod === mod_data
+		var mod_i = 1
+		dev_log(str("mod_load_order -> ", mod_i, ") ", mod.dir), LOG_NAME)
+		mod_i += 1
 
 	# Instance every mod and add it as a node to the Mod Loader
 	for mod in mod_load_order:

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -129,8 +129,8 @@ func _init():
 	_get_load_order()
 
 	# Log mod order
+	var mod_i = 1
 	for mod in mod_load_order: # mod === mod_data
-		var mod_i = 1
 		dev_log(str("mod_load_order -> ", mod_i, ") ", mod.dir), LOG_NAME)
 		mod_i += 1
 


### PR DESCRIPTION
Now only shows the mod paths plus their load number, instead of the full JSON data. This makes it much easier to see the load order itself, without all the extra data.

This fix also stops the full JSON data from being duplicated. As before, the full JSON is still shown, via the `dev_log` just before the end of `_init`.

Preview:
![mod_load_order-v2](https://user-images.githubusercontent.com/43499897/212526820-c8ee4912-04ec-4ded-a043-25ee4e13ab51.png)

Before:
![image](https://user-images.githubusercontent.com/43499897/212526656-b0a32bcf-0304-4800-b9f0-56e20f62efaf.png)
