### PR TITLE
Update manifest key validation to match Thunderstore requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,22 @@ Mods you create must have the following 2 files:
 
 ```json
 {
-	"id": "AuthorName-ModName",
-	"name": "Mod Name",
-	"version": "1.0.0",
-	"compatible_game_version": ["0.6.1.6"],
-	"authors": ["AuthorName"],
-	"description": "Mod description goes here",
-	"website_url": "",
-	"dependencies": [
-		"Add IDs of other mods here, if your mod needs them to work"
-	],
-	"incompatibilities": [
-		"Add IDs of other mods here, if your mod conflicts with them"
-	]
+    "name": "Invasion",
+    "version": "0.6.0",
+    "description": "Adds content from Space Gladiators",
+    "website_url": "https://github.com/BrotatoMods/Brotato-Invasion-Mod",
+    "dependencies": [
+        "Dami-ContentLoader",
+        "Darkly77-BFX"
+    ],
+    "extra": {
+        "godot": {
+            "id": "Darkly77-Invasion",
+            "incompatibilities": [],
+            "authors": ["Darkly77"],
+            "compatible_game_version": ["0.6.1.6"],
+        }
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,20 @@ Mods you create must have the following 2 files:
 
 ```json
 {
-    "name": "Invasion",
-    "version": "0.6.0",
-    "description": "Adds content from Space Gladiators",
-    "website_url": "https://github.com/BrotatoMods/Brotato-Invasion-Mod",
+    "name": "ModName",
+    "version": "1.0.0",
+    "description": "Mod description goes here",
+    "website_url": "https://github.com/example/repo",
     "dependencies": [
-        "Dami-ContentLoader",
-        "Darkly77-BFX"
+		"Add IDs of other mods here, if your mod needs them to work"
     ],
     "extra": {
         "godot": {
-            "id": "Darkly77-Invasion",
-            "incompatibilities": [],
-            "authors": ["Darkly77"],
+            "id": "AuthorName-ModName",
+            "incompatibilities": [
+				"Add IDs of other mods here, if your mod conflicts with them"
+			],
+            "authors": ["AuthorName"],
             "compatible_game_version": ["0.6.1.6"],
         }
     }


### PR DESCRIPTION
**Changes:**

- Updates the list of required manifest.json keys, to match the requirements of Thunderstore (see [issue](https://github.com/GodotModding/godot-mod-loader/issues/20#issuecomment-1380174626) / [Thunderstore docs](https://thunderstore.io/package/create/docs/))
- Logging: Puts every missing key onto its own file, improving readability
- Logging: Fixes a code error where the missing keys array wasn't cleared, causing missing keys to be duplicated in the logs

**Preview:**

![manifest-missing-fields--full](https://user-images.githubusercontent.com/43499897/212528421-7c3ad357-a3e4-4b18-8af6-75e82f8045d5.png)

**Related:**

- #20
- #26
