### PR TITLE
Config JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,30 @@ Save the scene as a PackedScene, overwriting Godot's cache if needed.
 
 ### get_mod_config
 
-    get_mod_config(mod_id:String = "", key:String = "")->Dictionary:
+    get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
 
 Get data from a mod's config JSON file. Configs are added to a folder named "configs" (`res://configs`), and are named by the mod ID (eg. `AuthorName-ModName.json`).
 
-Returns a dictionary with two keys: `error` and `data`:
+Returns a dictionary with two keys: `error` and `data`.
 
-- Data (`data`) is either the full config, or data from a specific key if one was specified.
-- Error (`error`) is `0` if there were no errors, or `> 0` if the setting could not be retrieved:
-  - `0` = No errors
-  - `1` = Invalid mod ID
-  - `2` = No config data available, the JSON file probably doesn't exist
-  - `3` = Invalid key, although config data does exists
+#### Data
+
+Data (`data`) is either the full config, or data from a specific key if one was specified. If an error occured, `data` is an empty dictionary (`{}`).
+
+#### Error
+
+Error (`error`) is `0` if there were no errors, or `> 0` if the setting could not be retrieved:
+
+| #   | Description |
+| --- | ----------- |
+| `0` | No errors |
+| `1` | Invalid mod ID |
+| `2` | No config data available, the JSON file probably doesn't exist |
+| `3` | Invalid key, although config data does exists |
+
+#### Defaults
+
+If `default_value` is provided and an error occurs, `data` will be `default_value`. This is most useful when getting a setting by key, as it saves you needing to add checks for errors. You could also pass a dictionary of default values.
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Mods you create must have the following 2 files:
 ```json
 {
 	"name": "ModName",
-	"version": "1.0.0",
+	"version_number": "1.0.0",
 	"description": "Mod description goes here",
 	"website_url": "https://github.com/example/repo",
 	"dependencies": [

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 For detailed info, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup and helper functions in much greater detail.
 
-- [Mod Setup](mod-setup)
-- [Helper Methods](helper-methods)
-- [Config JSON](config-json)
-- [CLI Args](cli-args)
+- [Mod Setup](#mod-setup)
+- [Helper Methods](#helper-methods)
+- [Config JSON](#config-json)
+- [CLI Args](#cli-args)
 
 
 ## Mod Setup

--- a/README.md
+++ b/README.md
@@ -137,19 +137,21 @@ Get data from a mod's config JSON file. Returns a dictionary with three keys: `d
 
 #### Data
 
-Data (`data`) is either the full config, or data from a specific key if one was specified. If an error occured, `data` is an empty dictionary (`{}`).
+Data (`data`) is either the full config, or data from a specific key if one was specified.
+
+If no user config JSON exists, `data` uses the defaults set in the mod's *manifest.json* (see [Config JSON](#config-json) below). Returns an empty dictionary (`{}`) if either a) the mod's *manifest.json* has no defaults, or b) the specified `key` doesn't exist.
 
 #### Error
 
 Error (`error`) is `0` if there were no errors, or `> 0` if the setting could not be retrieved:
 
-| #   | Description |
-| --- | ----------- |
-| `0` | No errors |
-| `1` | Invalid mod ID |
-| `2` | No custom JSON (file probably does not exist). Defaults will be used |
-| `3` | No custom JSON, and `key` was not present in your mod's defaults |
-| `4` | Invalid `key`, although config data does exists |
+| #   | Description | Data |
+| --- | ----------- | ---- |
+| `0` | No errors   | *As requested* |
+| `1` | Invalid `mod_id` | `{}` |
+| `2` | No custom JSON exists | Defaults from *manifest.json* |
+| `3` | Invalid `key`. Custom JSON does not exist | `{}` |
+| `4` | Invalid `key`. Custom JSON *does* exist | `{}` |
 
 #### Error Msg
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Mod ZIPs should have the structure shown below. The name of the ZIP is arbitrary
 yourmod.zip
 ├───.import
 └───mods-unpacked
-    └───Author-ModName
-        ├───mod_main.gd
-        └───manifest.json
+	└───Author-ModName
+		├───mod_main.gd
+		└───manifest.json
 ```
 
 #### Notes on .import
@@ -38,7 +38,7 @@ Mods you create must have the following 2 files:
 ```json
 {
 	"name": "ModName",
-    "namespace": "AuthorName",
+	"namespace": "AuthorName",
 	"version_number": "1.0.0",
 	"description": "Mod description goes here",
 	"website_url": "https://github.com/example/repo",
@@ -52,9 +52,9 @@ Mods you create must have the following 2 files:
 				"Add IDs of other mods here, if your mod conflicts with them"
 			],
 			"authors": ["AuthorName"],
-            "compatible_modloader_version": "3.0.0",
+			"compatible_modloader_version": "3.0.0",
 			"compatible_game_version": ["0.6.1.6"],
-            "config_defaults": {}
+			"config_defaults": {}
 		}
 	}
 }
@@ -82,15 +82,15 @@ One approach to organising your extender scripts is to put them in a dedicated f
 yourmod.zip
 ├───.import
 └───mods-unpacked
-    └───Author-ModName
-        ├───mod_main.gd
-        ├───manifest.json
-        └───extensions
-            └───Any files that extend vanilla code can go here, eg:
-            ├───main.gd
-            └───singletons
-                ├───item_service.gd
-                └───debug_service.gd
+	└───Author-ModName
+		├───mod_main.gd
+		├───manifest.json
+		└───extensions
+			└───Any files that extend vanilla code can go here, eg:
+			├───main.gd
+			└───singletons
+				├───item_service.gd
+				└───debug_service.gd
 ```
 
 ### addTranslationFromResource
@@ -115,7 +115,7 @@ Save the scene as a PackedScene, overwriting Godot's cache if needed.
 
 ### get_mod_config
 
-    get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
+	get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
 
 Get data from a mod's config JSON file. Configs are added by users, to a folder named *configs* (`res://configs`). They are named by the mod ID (eg. `AuthorName-ModName.json`).
 
@@ -156,7 +156,7 @@ The `load_from` JSON file should be in the same directory, and include the file 
 
 ```json
 {
-    "load_from": "my-special-config.json"
+	"load_from": "my-special-config.json"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 For detailed info, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup and helper functions in much greater detail.
 
+
+
 ## Mod Setup
 
 ### Structure
@@ -62,9 +64,23 @@ Mods you create must have the following 2 files:
 
 See `get_mod_config` below for info on `config_defaults`.
 
+
+
 ## Helper Methods
 
 Use these when creating your mods. As above, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md) for more details.
+
+### mod_log
+
+	func mod_log(text:String, mod_name:String = "Unknown-Mod", pretty:bool = false)->void
+
+Log data to *godot.log.*. The mod ID should be provided as the 2nd arg.
+
+### dev_log
+
+	func dev_log(text:String, mod_name:String = "Unknown-Mod", pretty:bool = false)
+
+Logs verbose info to *godot.log*, but only if developer logging is enabled, either via the CLI arg `--log-dev` or by temporarily changing the `DEBUG_ENABLE_DEV_LOG` to `true`.
 
 ### install_script_extension
 
@@ -139,6 +155,8 @@ Error (`error`) is `0` if there were no errors, or `> 0` if the setting could no
 
 Text representation of the error that occured, intended to make debugging easier.
 
+
+
 ## Config JSON
 
 ModLoader supports config files in the JSON format. Custom configs can be added by users, to a folder named *configs* (`res://configs`). They are named by the mod ID (eg. `AuthorName-ModName.json`).
@@ -164,6 +182,7 @@ The `load_from` JSON file should be in the same directory, and include the file 
 This allows users to multiple config files for a single mod and switch between them quickly. This settings is ignord if the filename matches the mod ID, or is empty.
 
 
+
 ## CLI Args
 
 ModLoader supports the following command line arguments:
@@ -175,6 +194,7 @@ ModLoader supports the following command line arguments:
 | `--log-dev`      | Enable developer logging. This is more verbose and can be used with the func `dev_log`. |
 
 You can use these in the Godot editor via *Project > Project Settings > Display > Editor > Main Run Args*
+
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ Save the scene as a PackedScene, overwriting Godot's cache if needed.
 
 	get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
 
-Get data from a mod's config JSON file. Configs are added by users, to a folder named *configs* (`res://configs`). They are named by the mod ID (eg. `AuthorName-ModName.json`).
-
-Returns a dictionary with three keys: `data`, `error`, and `error_msg`.
+Get data from a mod's config JSON file. Returns a dictionary with three keys: `data`, `error`, and `error_msg`, which are explained below.
 
 #### Data
 
@@ -141,14 +139,17 @@ Error (`error`) is `0` if there were no errors, or `> 0` if the setting could no
 
 Text representation of the error that occured, intended to make debugging easier.
 
+## Config JSON
+
+ModLoader supports config files in the JSON format. Custom configs can be added by users, to a folder named *configs* (`res://configs`). They are named by the mod ID (eg. `AuthorName-ModName.json`).
+
 ### Defaults
 
-If no custom JSON file exists, your mod's default settings will be returned as `data`. This only applies if you're not using a `key`, or the `key` you provide exists in your defaults.
+Default settings can be set in your *manifest.json* file, via `extra.godot.config_defaults`.
 
-Default settings are set in your *manifest.json* file, via `extra.godot.config_defaults`.
+If you use `get_mod_config` when no custom JSON file exists, your mod's default settings will be used instead (returned as `data`). This works wheter you're using `key` or not.
 
-
-## Config Options
+### Config Options
 
 A user's custom config file can use a special setting, `load_from`. If specified, their config is loaded from the specified file, instead of the file named after the mod ID.
 
@@ -171,7 +172,7 @@ ModLoader supports the following command line arguments:
 | --- | ---- |
 | `--mods-path`    | Override the path to the mod ZIPs dir. Default path is `res://mods` |
 | `--configs-path` | Override the path to the config JSONs dir. Default path is `res://configs` |
-| `--mod-dev`      | Enable developer logging. This is more verbose and can be used with the func `dev_log`. |
+| `--log-dev`      | Enable developer logging. This is more verbose and can be used with the func `dev_log`. |
 
 You can use these in the Godot editor via *Project > Project Settings > Display > Editor > Main Run Args*
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Mod ZIPs should have the structure shown below. The name of the ZIP is arbitrary
 yourmod.zip
 ├───.import
 └───mods-unpacked
-	└───Author-ModName
-		├───mod_main.gd
-		└───manifest.json
+    └───Author-ModName
+        ├───mod_main.gd
+        └───manifest.json
 ```
 
 #### Notes on .import
@@ -82,15 +82,15 @@ One approach to organising your extender scripts is to put them in a dedicated f
 yourmod.zip
 ├───.import
 └───mods-unpacked
-	└───Author-ModName
-		├───mod_main.gd
-		├───manifest.json
-		└───extensions
-			└───Any files that extend vanilla code can go here, eg:
-			├───main.gd
-			└───singletons
-				├───item_service.gd
-				└───debug_service.gd
+    └───Author-ModName
+        ├───mod_main.gd
+        ├───manifest.json
+        └───extensions
+            └───Any files that extend vanilla code can go here, eg:
+            ├───main.gd
+            └───singletons
+                ├───item_service.gd
+                └───debug_service.gd
 ```
 
 ### addTranslationFromResource

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use these when creating your mods. As above, see the [docs for Delta-V Modding](
 
 Add a script that extends a vanilla script. `childScriptPath` is the path to your mod's extender script path, eg `MOD/extensions/singletons/utils.gd`.
 
-Inside that extender script, it should include `extends {target}`, where {target} is the vanilla path, eg: `extends "res://singletons/utils.gd"`.
+Inside that extender script, it should include `extends "{target}"`, where `{target}` is the vanilla path, eg: `extends "res://singletons/utils.gd"`.
 
 Your extender scripts don't have to follow the same directory path as the vanilla file, but it's good practice to do so.
 

--- a/README.md
+++ b/README.md
@@ -37,25 +37,24 @@ Mods you create must have the following 2 files:
 
 ```json
 {
-    "name": "ModName",
-    "version": "1.0.0",
-    "description": "Mod description goes here",
-    "website_url": "https://github.com/example/repo",
-    "dependencies": [
+	"name": "ModName",
+	"version": "1.0.0",
+	"description": "Mod description goes here",
+	"website_url": "https://github.com/example/repo",
+	"dependencies": [
 		"Add IDs of other mods here, if your mod needs them to work"
-    ],
-    "extra": {
-        "godot": {
-            "id": "AuthorName-ModName",
-            "incompatibilities": [
+	],
+	"extra": {
+		"godot": {
+			"id": "AuthorName-ModName",
+			"incompatibilities": [
 				"Add IDs of other mods here, if your mod conflicts with them"
 			],
-            "authors": ["AuthorName"],
-            "compatible_game_version": ["0.6.1.6"],
-        }
-    }
+			"authors": ["AuthorName"],
+			"compatible_game_version": ["0.6.1.6"],
+		}
+	}
 }
-```
 
 #### Notes on meta.json
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Mods you create must have the following 2 files:
 				"Add IDs of other mods here, if your mod conflicts with them"
 			],
 			"authors": ["AuthorName"],
+            "compatible_modloader_version": "3.0.0",
 			"compatible_game_version": ["0.6.1.6"],
             "config_defaults": {}
 		}

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ Create and add a node to a instanced scene.
 
 Save the scene as a PackedScene, overwriting Godot's cache if needed.
 
+### get_mod_config
+
+    get_mod_config(mod_id:String = "", key:String = "")->Dictionary:
+
+Get data from a mod's config JSON file. Configs are added to a folder named "configs" (`res://configs`), and are named by the mod ID (eg. `AuthorName-ModName.json`).
+
+Returns a dictionary with two keys: `error` and `data`:
+
+- Data (`data`) is either the full config, or data from a specific key if one was specified.
+- Error (`error`) is `0` if there were no errors, or `> 0` if the setting could not be retrieved:
+  - `0` = No errors
+  - `1` = Invalid mod ID
+  - `2` = No config data available, the JSON file probably doesn't exist
+  - `3` = Invalid key, although config data does exists
+
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Mods you create must have the following 2 files:
 		}
 	}
 }
+```
 
 #### Notes on meta.json
 

--- a/README.md
+++ b/README.md
@@ -57,17 +57,6 @@ Mods you create must have the following 2 files:
 }
 ```
 
-#### Notes on meta.json
-
-Some properties in the JSON are not checked in the code, and are only used for reference by yourself and your mod's users. These are:
-
-- `version`
-- `compatible_game_version`
-- `authors`
-- `description`
-- `website_url`
-
-
 ## Helper Methods
 
 Use these when creating your mods. As above, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If no custom JSON file exists, your mod's default settings will be returned as `
 Default settings are set in your *manifest.json* file, via `extra.godot.config_defaults`.
 
 
-### Config Options
+## Config Options
 
 A user's custom config file can use a special setting, `load_from`. If specified, their config is loaded from the specified file, instead of the file named after the mod ID.
 
@@ -161,6 +161,19 @@ The `load_from` JSON file should be in the same directory, and include the file 
 ```
 
 This allows users to multiple config files for a single mod and switch between them quickly. This settings is ignord if the filename matches the mod ID, or is empty.
+
+
+## CLI Args
+
+ModLoader supports the following command line arguments:
+
+| Arg | Info |
+| --- | ---- |
+| `--mods-path`    | Override the path to the mod ZIPs dir. Default path is `res://mods` |
+| `--configs-path` | Override the path to the config JSONs dir. Default path is `res://configs` |
+| `--mod-dev`      | Enable developer logging. This is more verbose and can be used with the func `dev_log`. |
+
+You can use these in the Godot editor via *Project > Project Settings > Display > Editor > Main Run Args*
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Mods you create must have the following 2 files:
 ```json
 {
 	"name": "ModName",
+    "namespace": "AuthorName",
 	"version_number": "1.0.0",
 	"description": "Mod description goes here",
 	"website_url": "https://github.com/example/repo",

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ See `get_mod_config` below for info on `config_defaults`.
 
 Use these when creating your mods. As above, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md) for more details.
 
+| Method | Description |
+| ------ | ----------- |
+| [mod_log](#mod_log) | Log data to *godot.log.* |
+| [dev_log](#dev_log) | Log verbose data to *godot.log.* Only shows if dev logging is enabled |
+| [install_script_extension](#install_script_extension) | Extend a vanilla script |
+| [add_translation_from_resource](#add_translation_from_resource) | Import a translation file (eg `mod_text.en.translation`) |
+| [append_node_in_scene](#append_node_in_scene) | Create and add a node to a instanced scene |
+| [save_scene](#save_scene) | Save the scene as a PackedScene, overwriting Godot's cache if needed |
+| [get_mod_config](#get_mod_config) | Get data from a mod's config JSON file |
+
 ### mod_log
 
 	func mod_log(text:String, mod_name:String = "Unknown-Mod", pretty:bool = false)->void
@@ -90,7 +100,9 @@ Logs verbose info to *godot.log*, but only if developer logging is enabled, eith
 
 	func install_script_extension(child_script_path:String)
 
-Add a script that extends a vanilla script. `child_script_path` is the path to your mod's extender script path, eg `MOD/extensions/singletons/utils.gd`.
+Add a script that extends a vanilla script. This allows you to overwrite funcs, extend them, and add your own. See [Script Inheritance](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md#script-inheritance) in the Delta-V modding readme for more info on usage.
+
+`child_script_path` is the path to your mod's extender script path, eg `MOD/extensions/singletons/utils.gd`.
 
 Inside that extender script, it should include `extends "{target}"`, where `{target}` is the vanilla path, eg: `extends "res://singletons/utils.gd"`.
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ Mods you create must have the following 2 files:
 			],
 			"authors": ["AuthorName"],
 			"compatible_game_version": ["0.6.1.6"],
+            "config_defaults": {}
 		}
 	}
 }
 ```
+
+See `get_mod_config` below for info on `config_defaults`.
 
 ## Helper Methods
 
@@ -112,9 +115,9 @@ Save the scene as a PackedScene, overwriting Godot's cache if needed.
 
     get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
 
-Get data from a mod's config JSON file. Configs are added to a folder named "configs" (`res://configs`), and are named by the mod ID (eg. `AuthorName-ModName.json`).
+Get data from a mod's config JSON file. Configs are added by users, to a folder named *configs* (`res://configs`). They are named by the mod ID (eg. `AuthorName-ModName.json`).
 
-Returns a dictionary with two keys: `error` and `data`.
+Returns a dictionary with three keys: `data`, `error`, and `error_msg`.
 
 #### Data
 
@@ -128,12 +131,34 @@ Error (`error`) is `0` if there were no errors, or `> 0` if the setting could no
 | --- | ----------- |
 | `0` | No errors |
 | `1` | Invalid mod ID |
-| `2` | No config data available, the JSON file probably doesn't exist |
-| `3` | Invalid key, although config data does exists |
+| `2` | No custom JSON (file probably does not exist). Defaults will be used |
+| `3` | No custom JSON, and `key` was not present in your mod's defaults |
+| `4` | Invalid `key`, although config data does exists |
 
-#### Defaults
+#### Error Msg
 
-If `default_value` is provided and an error occurs, `data` will be `default_value`. This is most useful when getting a setting by key, as it saves you needing to add checks for errors. You could also pass a dictionary of default values.
+Text representation of the error that occured, intended to make debugging easier.
+
+### Defaults
+
+If no custom JSON file exists, your mod's default settings will be returned as `data`. This only applies if you're not using a `key`, or the `key` you provide exists in your defaults.
+
+Default settings are set in your *manifest.json* file, via `extra.godot.config_defaults`.
+
+
+### Config Options
+
+A user's custom config file can use a special setting, `load_from`. If specified, their config is loaded from the specified file, instead of the file named after the mod ID.
+
+The `load_from` JSON file should be in the same directory, and include the file extension, eg:
+
+```json
+{
+    "load_from": "my-special-config.json"
+}
+```
+
+This allows users to multiple config files for a single mod and switch between them quickly. This settings is ignord if the filename matches the mod ID, or is empty.
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 For detailed info, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup and helper functions in much greater detail.
 
+- [Mod Setup](mod-setup)
+- [Helper Methods](helper-methods)
+- [Config JSON](config-json)
+- [CLI Args](cli-args)
 
 
 ## Mod Setup

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -63,6 +63,7 @@ const REQUIRED_MANIFEST_KEYS_EXTRA = [
 	"id",
 	"incompatibilities",
 	"authors",
+	"compatible_modloader_version",
 	"compatible_game_version",
 	"config_defaults",
 ]

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -750,15 +750,12 @@ func append_node_in_scene(modified_scene, node_name:String = "", node_parent = n
 		new_node.set_owner(modified_scene)
 
 
-func save_scene(modified_scene, scene_path:String):
+func save_scene(modified_scene, scenePath:String):
 	var packed_scene = PackedScene.new()
-
-	dev_log(str("packing scene -> ", packed_scene), LOG_NAME)
 	packed_scene.pack(modified_scene)
-
-	dev_log(str("save_scene - taking over path - new path -> ", packed_scene.resource_path), LOG_NAME)
-	packed_scene.take_over_path(scene_path)
-
+	dev_log(str("packing scene -> ", packed_scene), LOG_NAME)
+	packed_scene.take_over_path(scenePath)
+	dev_log(str("saveScene - taking over path - new path -> ", packed_scene.resource_path), LOG_NAME)
 	_saved_objects.append(packed_scene)
 
 

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -27,7 +27,7 @@ extends Node
 # options (which should be `false` when distributing compiled PCKs)
 
 # Enables logging messages made with dev_log. Usually these are enabled with the
-# command line arg `--mod-dev`, but you can also enable them this way if you're
+# command line arg `--log-dev`, but you can also enable them this way if you're
 # debugging in the editor
 const DEBUG_ENABLE_DEV_LOG = false
 
@@ -188,9 +188,9 @@ func _init():
 
 
 # Log developer info. Has to be enabled, either with the command line arg
-# `--mod-dev`, or by temporarily enabling DEBUG_ENABLE_DEV_LOG
+# `--log-dev`, or by temporarily enabling DEBUG_ENABLE_DEV_LOG
 func dev_log(text:String, mod_name:String = "Unknown-Mod", pretty:bool = false):
-	if DEBUG_ENABLE_DEV_LOG || (_check_cmd_line_arg("--mod-dev")):
+	if DEBUG_ENABLE_DEV_LOG || (_check_cmd_line_arg("--log-dev")):
 		mod_log(text, mod_name, pretty)
 
 

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -726,10 +726,10 @@ func installScriptExtension(childScriptPath:String):
 # Add a translation file, eg "mytranslation.en.translation". The translation
 # file should have been created in Godot already: When you improt a CSV, such
 # a file will be created for you.
-func addTranslationFromResource(resourcePath: String):
-	var translation_object = load(resourcePath)
+func add_translation_from_resource(resource_path: String):
+	var translation_object = load(resource_path)
 	TranslationServer.add_translation(translation_object)
-	mod_log("Added Translation from Resource", LOG_NAME)
+	mod_log(str("Added Translation from Resource -> ", resource_path), LOG_NAME)
 
 
 func appendNodeInScene(modifiedScene, nodeName:String = "", nodeParent = null, instancePath:String = "", isVisible:bool = true):

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -115,7 +115,7 @@ func _init():
 		return
 
 	# Log game install dir
-	mod_log(str("gameInstallDirectory: ", _get_local_folder_dir()), LOG_NAME)
+	mod_log(str("game_install_directory: ", _get_local_folder_dir()), LOG_NAME)
 
 	# check if we want to use a different mods path that is provided as a command line argument
 	var cmd_line_mod_path = _get_cmd_line_arg("--mods-path")

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -339,7 +339,7 @@ func _setup_mods():
 
 # Load mod config JSONs from res://configs
 func _load_mod_configs():
-	var found_1_config = false
+	var found_configs_count = 0
 	var configs_path = _get_local_folder_dir("configs")
 
 	# CLI override, set with `--configs-path="C://path/configs"`
@@ -354,7 +354,7 @@ func _load_mod_configs():
 		dev_log(str("Config JSON: Looking for config at path: ", json_path), LOG_NAME)
 
 		if mod_config.size() > 0:
-			found_1_config = true
+			found_configs_count += 1
 
 			mod_log(str("Config JSON: Found a config file: '", json_path, "'"), LOG_NAME)
 			dev_log(str("Config JSON: File data: ", JSON.print(mod_config)), LOG_NAME)
@@ -378,7 +378,9 @@ func _load_mod_configs():
 
 			mod_data[mod_id].config = mod_config
 
-	if !found_1_config:
+	if found_configs_count > 0:
+		mod_log(str("Config JSON: Loaded ", str(found_configs_count), " config(s)"), LOG_NAME)
+	else:
 		mod_log(str("Config JSON: No mod configs were found"), LOG_NAME)
 
 

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -51,6 +51,7 @@ const REQUIRED_MOD_FILES = ["mod_main.gd", "manifest.json"]
 # Required keys in a mod's manifest.json file
 const REQUIRED_MANIFEST_KEYS_ROOT = [
 	"name",
+	"namespace",
 	"version_number",
 	"website_url",
 	"description",

--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -759,12 +759,12 @@ func saveScene(modifiedScene, scenePath:String):
 
 # Get the config data for a specific mod. Always returns a dictionary with two
 # keys: `error` and `data`.
-# Data (`data`) is either the full config, or data fro a specific key if one was specified.
+# Data (`data`) is either the full config, or data from a specific key if one was specified.
 # Error (`error`) is 0 if there were no errors, or > 0 if the setting could not be retrieved:
 # 1 = Invalid mod ID
 # 2 = No config data available, the JSON file probably doesn't exist
 # 3 = Invalid key, although config data does exists
-func get_mod_config(mod_id:String = "", key:String = "")->Dictionary:
+func get_mod_config(mod_id:String = "", key:String = "", default_value = null)->Dictionary:
 	var error_num = 0
 	var error_msg = ""
 	var data = {}
@@ -792,6 +792,8 @@ func get_mod_config(mod_id:String = "", key:String = "")->Dictionary:
 
 	if error_num != 0:
 		dev_log(str("Config: ", error_msg), mod_id)
+		if default_value != null:
+			data = default_value
 
 	return {
 		"error": error_num,


### PR DESCRIPTION
Note: I've tested this extensively, incl. with the CLI args, so there shouldn't be any issues or errors unless I've completely missed something

**Config JSONs**

- Adds support for per-mod config JSONs in `res://configs`. View the README for full details.
- Provides a new utility func `get_mod_config(mod_id, key)`.
  - This can be used to get the full data, or data from a specific key.
  - Includes extensive validation, with error messages and codes listed in the README.
- Supports setting default options via a new required manifest key, `config_defaults`. 
  - If set, using `get_mod_config` when no custom JSON file is present will return your manifest's defaults instead.
- Includes support for overwriting the configs dir with a CLI arg, `--configs-path`.
  - Follows the precedent set by of #28.
- Closes #15.

**Misc Changes**

- Lots of improvements to README: 
  - Add table of contents
  - Docs for `mod_log` and `dev_log` methods
  - New sections for CLI Args & Config Options
  - Overview table for Helper Methods
  - Change spaces to tabs for the JSON examples
- Adds or improves a few comments
- Adds required manifest key: `namespace` (`AuthorName`)
- Adds required manifest key: `compatible_modloader_version`.
  - This lets us implement #13 at a later date, without breaking compatibility with mods built for this version of ModLoader.

**Breaking Changes**

- manifest.json key: `namespace`
- manifest.json key: `extra.godot.config_defaults`
- manifest.json key: `extra.godot.compatible_modloader_version`
