### PR TITLE
Rename CLI arg `mod-dev` to `log-dev`

### DIFF
--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -27,7 +27,7 @@ extends Node
 # options (which should be `false` when distributing compiled PCKs)
 
 # Enables logging messages made with dev_log. Usually these are enabled with the
-# command line arg `--mod-dev`, but you can also enable them this way if you're
+# command line arg `--log-dev`, but you can also enable them this way if you're
 # debugging in the editor
 const DEBUG_ENABLE_DEV_LOG = false
 
@@ -164,9 +164,9 @@ func _init():
 
 
 # Log developer info. Has to be enabled, either with the command line arg
-# `--mod-dev--mod-dev`, or by temporarily enabling DEBUG_ENABLE_DEV_LOG
+# `--log-dev`, or by temporarily enabling DEBUG_ENABLE_DEV_LOG
 func dev_log(text:String, mod_name:String = "", pretty:bool = false):
-	if DEBUG_ENABLE_DEV_LOG || (_check_cmd_line_arg("--mod-dev")):
+	if DEBUG_ENABLE_DEV_LOG || (_check_cmd_line_arg("--log-dev")):
 		mod_log(text, mod_name, pretty)
 
 


### PR DESCRIPTION
Renames the dev logging CLI arg. It's now more indicative of its purpose.