### PR TITLE
Log resource path in `add_translation_from_resource`

### DIFF
--- a/loader/mod_loader.gd
+++ b/loader/mod_loader.gd
@@ -666,7 +666,7 @@ func install_script_extension(child_script_path:String):
 func add_translation_from_resource(resource_path: String):
 	var translation_object = load(resource_path)
 	TranslationServer.add_translation(translation_object)
-	mod_log("Added Translation from Resource", LOG_NAME)
+	mod_log(str("Added Translation from Resource -> ", resource_path), LOG_NAME)
 
 
 func append_node_in_scene(modified_scene, node_name:String = "", node_parent = null, instance_path:String = "", is_visible:bool = true):


### PR DESCRIPTION
Makes `add_translation_from_resource` log the resource path.

Previously it only logged that a translation was added, with no indication on where it came from