### PR TITLE
README - remove `id` from example json

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Mods you create must have the following 2 files:
 	],
 	"extra": {
 		"godot": {
-			"id": "AuthorName-ModName",
 			"incompatibilities": [
 				"Add IDs of other mods here, if your mod conflicts with them"
 			],


### PR DESCRIPTION
Remove `id` from the README's example JSON

This should have been done in #51 but was missed