### PR TITLE
README - Strip to basics (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,3 @@ A general purpose mod-loader for GDScript-based Godot Games.
 1. Create your [Mod Structure](Mod-Structure)
 1. Create your [Mod Files](Mod-Files)
 1. Use the [API Methods](API-Methods)
-
-
-## Credits
-
-🔥 ModLoader is based on the work of these brilliant people 🔥
-
-- [Delta-V-Modding](https://gitlab.com/Delta-V-Modding/Mods)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 ## Getting Started
 
+1. Add ModLoader to your [Godot Project](Godot-Project-Setup).
 1. Create your [Mod Structure](Mod-Structure)
 1. Create your [Mod Files](Mod-Files)
 1. Use the [API Methods](API-Methods)

--- a/README.md
+++ b/README.md
@@ -2,112 +2,13 @@
 
 A general purpose mod-loader for GDScript-based Godot Games.
 
-See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for additional details, including [Helper Methods](https://github.com/GodotModding/godot-mod-loader/wiki/Helper-Methods) and [CLI Args](https://github.com/GodotModding/godot-mod-loader/wiki/CLI-Args).
+## Getting Started
 
-*See also: The [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup in much greater detail.*
+1. Create your [Mod Structure](Mod-Structure)
+1. Create your [Mod Files](Mod-Files)
+1. Use the [API Methods](API-Methods)
 
-## Mod Structure
-
-### Editor
-
-When developing mods in Godot, create a folder named *mods-unpacked* and add your mods there. Mod folder names **must** follow the convention of `{AuthorName}-{ModName}`:
-
-If you have any dependencies, you can also add them to *mods-unpacked*. Note that due to a bug in Godot, you cannot use zipped mods, as they prevent the editor from reading the contents of the *mods-unpacked* directory.
-
-```
-res://
-└───mods-unpacked
-    └───Author-ModName
-        ├───mod_main.gd
-        └───manifest.json
-```
-
-### ZIPs
-
-Mod ZIPs should have the structure shown below. The name of the ZIP is arbitrary.
-
-```
-yourmod.zip
-├───.import
-└───mods-unpacked
-    └───Author-ModName
-        ├───mod_main.gd
-        └───manifest.json
-```
-
-#### Custom Assets
-
-If your mod includes custom assets such as PNGs and CSVs, these files should be included in your mod ZIP. Like in the editor, these go in a top-level directory called *.import*.
-
-Your mod ZIP's .import folder **should only include your custom assets**. It should not include any vanilla files.
-
-<details>
-<summary><em>Notes on .import</em></summary>
-<em>Custom assets can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.</em>
-</details>
-
-## Mod Files
-
-Mods you create must have the following 2 files:
-
-- **mod_main.gd** - The init file for your mod
-- **manifest.json** - Meta data for your mod
-
-#### Example mod_main.gd
-
-```gdscript
-extends Node
-
-const MOD_DIR = "AuthorName-ModName/"
-const LOG_NAME = "AuthorName-ModName"
-
-var dir = ""
-var ext_dir = ""
-var trans_dir = ""
-
-func _init(modLoader = ModLoader):
-	modLoader.mod_log("Init", LOG_NAME)
-	dir = modLoader.UNPACKED_DIR + MOD_DIR
-	ext_dir = dir + "extensions/"
-	trans_dir = dir + "translations/"
-
-	# Add extensions
-	modLoader.install_script_extension(ext_dir + "main.gd")
-
-	# Add translations
-	modLoader.add_translation_from_resource(trans_dir + "translations/bfx.en.translation")
-
-
-func _ready():
-	ModLoader.mod_log("Done", LOG_NAME)
-```
-
-#### Example manifest.json
-
-```json
-{
-	"name": "ModName",
-	"namespace": "AuthorName",
-	"version_number": "1.0.0",
-	"description": "Mod description goes here",
-	"website_url": "https://github.com/example/repo",
-	"dependencies": [
-		"Add IDs of other mods here, if your mod needs them to work"
-	],
-	"extra": {
-		"godot": {
-			"id": "AuthorName-ModName",
-			"incompatibilities": [
-				"Add IDs of other mods here, if your mod conflicts with them"
-			],
-			"authors": ["AuthorName"],
-			"compatible_mod_loader_version": "3.0.0",
-			"compatible_game_version": ["0.6.1.6"],
-			"config_defaults": {}
-		}
-	}
-}
-```
+See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for more details, including [Helper Methods](https://github.com/GodotModding/godot-mod-loader/wiki/Helper-Methods) and [CLI Args](https://github.com/GodotModding/godot-mod-loader/wiki/CLI-Args).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 ## Getting Started
 
-1. Add ModLoader to your [Godot Project](Godot-Project-Setup).
+1. Add ModLoader to your [Godot Project](Godot-Project-Setup)
 1. Create your [Mod Structure](Mod-Structure)
 1. Create your [Mod Files](Mod-Files)
 1. Use the [API Methods](API-Methods)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for additi
 
 ### Editor
 
-When developing mods in Godot, create a folder named `mods-unpacked` and add your mods there. Mod folder names **must** follow the convention of `{AuthorName}-{ModName}`:
+When developing mods in Godot, create a folder named *mods-unpacked* and add your mods there. Mod folder names **must** follow the convention of `{AuthorName}-{ModName}`:
+
+If you have any dependencies, you can also add them to *mods-unpacked*. Note that due to a bug in Godot, you cannot use zipped mods, as they prevent the editor from reading the contents of the *mods-unpacked* directory.
 
 ```
 res://
@@ -33,12 +35,16 @@ yourmod.zip
         └───manifest.json
 ```
 
-#### Notes on .import
+#### Custom Assets
 
-Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder **should only include your custom assets**, and **should not** include any vanilla files.
+If your mod includes custom assets such as PNGs and CSVs, these files should be included in your mod ZIP. Like in the editor, these go in a top-level directory called *.import*.
 
-You can copy your custom assets from your project's .import directory. They can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.
+Your mod ZIP's .import folder **should only include your custom assets**. It should not include any vanilla files.
 
+<details>
+<summary><em>Notes on .import</em></summary>
+<em>Custom assets can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.</em>
+</details>
 
 ## Mod Files
 
@@ -49,7 +55,7 @@ Mods you create must have the following 2 files:
 
 #### Example mod_main.gd
 
-```gd
+```gdscript
 extends Node
 
 const MOD_DIR = "AuthorName-ModName/"

--- a/README.md
+++ b/README.md
@@ -4,12 +4,23 @@ A general purpose mod-loader for GDScript-based Godot Games.
 
 See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for additional details, including [Helper Methods](https://github.com/GodotModding/godot-mod-loader/wiki/Helper-Methods) and [CLI Args](https://github.com/GodotModding/godot-mod-loader/wiki/CLI-Args).
 
+*See also: The [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup in much greater detail.*
 
-## Mod Setup
+## Mod Structure
 
-For more info, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup in much greater detail.
+### Editor
 
-### Structure
+When developing mods in Godot, create a folder named `mods-unpacked` and add your mods there. Mod folder names **must** follow the convention of `{AuthorName}-{ModName}`:
+
+```
+res://
+└───mods-unpacked
+    └───Author-ModName
+        ├───mod_main.gd
+        └───manifest.json
+```
+
+### ZIPs
 
 Mod ZIPs should have the structure shown below. The name of the ZIP is arbitrary.
 
@@ -24,12 +35,12 @@ yourmod.zip
 
 #### Notes on .import
 
-Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder should **only** include your custom assets, and should not include any vanilla files.
+Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder **should only include your custom assets**, and **should not** include any vanilla files.
 
 You can copy your custom assets from your project's .import directory. They can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.
 
 
-### Required Files
+## Mod Files
 
 Mods you create must have the following 2 files:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A general purpose mod-loader for GDScript-based Godot Games.
 1. Create your [Mod Files](Mod-Files)
 1. Use the [API Methods](API-Methods)
 
-See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for more details, including [Helper Methods](https://github.com/GodotModding/godot-mod-loader/wiki/Helper-Methods) and [CLI Args](https://github.com/GodotModding/godot-mod-loader/wiki/CLI-Args).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,4 @@
 
 A general purpose mod-loader for GDScript-based Godot Games.
 
-## Getting Started
-
-1. Add ModLoader to your [Godot Project](Godot-Project-Setup)
-1. Create your [Mod Structure](Mod-Structure)
-1. Create your [Mod Files](Mod-Files)
-1. Use the [API Methods](API-Methods)
+View the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki/) for more information.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ yourmod.zip
         └───manifest.json
 ```
 
-#### Notes on .import
-
+<details>
+<summary>Notes on .import</summary>
 Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder should **only** include your custom assets, and should not include any vanilla files.
 
 You can copy your custom assets from your project's .import directory. They can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.
-
+</details>
 
 ### Required Files
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ yourmod.zip
         └───manifest.json
 ```
 
-<details>
-<summary>Notes on .import</summary>
+#### Notes on .import
+
 Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder should **only** include your custom assets, and should not include any vanilla files.
 
 You can copy your custom assets from your project's .import directory. They can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.
-</details>
+
 
 ### Required Files
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,37 @@ You can copy your custom assets from your project's .import directory. They can 
 
 Mods you create must have the following 2 files:
 
-- **mod_main.gd** - The init file for your mod.
-- **manifest.json** - Meta data for your mod (see below).
+- **mod_main.gd** - The init file for your mod
+- **manifest.json** - Meta data for your mod
+
+#### Example mod_main.gd
+
+```gd
+extends Node
+
+const MOD_DIR = "AuthorName-ModName/"
+const LOG_NAME = "AuthorName-ModName"
+
+var dir = ""
+var ext_dir = ""
+var trans_dir = ""
+
+func _init(modLoader = ModLoader):
+	modLoader.mod_log("Init", LOG_NAME)
+	dir = modLoader.UNPACKED_DIR + MOD_DIR
+	ext_dir = dir + "extensions/"
+	trans_dir = dir + "translations/"
+
+	# Add extensions
+	modLoader.install_script_extension(ext_dir + "main.gd")
+
+	# Add translations
+	modLoader.add_translation_from_resource(trans_dir + "translations/bfx.en.translation")
+
+
+func _ready():
+	ModLoader.mod_log("Done", LOG_NAME)
+```
 
 #### Example manifest.json
 


### PR DESCRIPTION
I have migrated all the README content to the [wiki](https://github.com/GodotModding/godot-mod-loader/wiki), which now has a proper "Getting Started" section.

Preview:
https://github.com/ithinkandicode/godot-mod-loader/tree/readme-example-mod_main

Alternate approach that duplicates content from the wiki: #57