### PR TITLE
README - Migrate content to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,68 +2,13 @@
 
 A general purpose mod-loader for GDScript-based Godot Games.
 
-See the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki) for additional details, including [Helper Methods](https://github.com/GodotModding/godot-mod-loader/wiki/Helper-Methods) and [CLI Args](https://github.com/GodotModding/godot-mod-loader/wiki/CLI-Args).
+## Getting Started
 
+View the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki/) for more information.
 
-## Mod Setup
+1. Add ModLoader to your [Godot Project](Godot-Project-Setup).
+1. Create your [Mod Structure](Mod-Structure)
+1. Create your [Mod Files](Mod-Files)
+1. Use the [API Methods](API-Methods)
 
-For more info, see the [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there cover mod setup in much greater detail.
-
-### Structure
-
-Mod ZIPs should have the structure shown below. The name of the ZIP is arbitrary.
-
-```
-yourmod.zip
-├───.import
-└───mods-unpacked
-    └───Author-ModName
-        ├───mod_main.gd
-        └───manifest.json
-```
-
-#### Notes on .import
-
-Adding the .import directory is only needed when your mod adds content such as PNGs and sound files. In these cases, your mod's .import folder should **only** include your custom assets, and should not include any vanilla files.
-
-You can copy your custom assets from your project's .import directory. They can be easily identified by sorting by date. To clean up unused files, it's helpful to delete everything in .import that's not vanilla, then run the game again, which will re-create only the files that are actually used.
-
-
-### Required Files
-
-Mods you create must have the following 2 files:
-
-- **mod_main.gd** - The init file for your mod.
-- **manifest.json** - Meta data for your mod (see below).
-
-#### Example manifest.json
-
-```json
-{
-	"name": "ModName",
-	"namespace": "AuthorName",
-	"version_number": "1.0.0",
-	"description": "Mod description goes here",
-	"website_url": "https://github.com/example/repo",
-	"dependencies": [
-		"Add IDs of other mods here, if your mod needs them to work"
-	],
-	"extra": {
-		"godot": {
-			"incompatibilities": [
-				"Add IDs of other mods here, if your mod conflicts with them"
-			],
-			"authors": ["AuthorName"],
-			"compatible_mod_loader_version": "3.0.0",
-			"compatible_game_version": ["0.6.1.6"],
-			"config_defaults": {}
-		}
-	}
-}
-```
-
-## Credits
-
-🔥 ModLoader is based on the work of these brilliant people 🔥
-
-- [Delta-V-Modding](https://gitlab.com/Delta-V-Modding/Mods)
+*See also: The [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there will be migrated to this wiki over time.*

--- a/README.md
+++ b/README.md
@@ -10,5 +10,3 @@ View the [Wiki](https://github.com/GodotModding/godot-mod-loader/wiki/) for more
 1. Create your [Mod Structure](Mod-Structure)
 1. Create your [Mod Files](Mod-Files)
 1. Use the [API Methods](API-Methods)
-
-*See also: The [docs for Delta-V Modding](https://gitlab.com/Delta-V-Modding/Mods/-/blob/main/MODDING.md), upon which ModLoader is based. The docs there will be migrated to this wiki over time.*


### PR DESCRIPTION
I have migrated all the README content to the [wiki](https://github.com/GodotModding/godot-mod-loader/wiki), which now has a proper "Getting Started" section.

I've also duped the wiki's Getting started section to the readme, so visitors have an entry point and the readme doesn't look bare.

Preview:
https://github.com/ithinkandicode/godot-mod-loader/tree/readme-basic-v2