### PR TITLE
Minor fixes to `manifest`

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -337,7 +337,7 @@ func _check_dependencies(mod_id:String, deps:Array):
 			continue
 
 		var dependency = mod_data[dependency_id]
-		var dependency_mod_manifest = mod_data[dependency_id].mod_manifest
+		var dependency_mod_manifest = mod_data[dependency_id].manifest
 
 		# Init the importance score if it's missing
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -497,7 +497,7 @@ func get_mod_config(mod_id:String = "", key:String = "")->Dictionary:
 	# Mod ID is valid
 	if error_num == 0:
 		var config_data = mod_data[mod_id].config
-		defaults = mod_data[mod_id].mod_manifest.extra.godot.config_defaults
+		defaults = mod_data[mod_id].manifest.config_defaults
 
 		# No custom JSON file
 		if config_data.size() == 0:

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -23,6 +23,7 @@ var compatible_game_version := [] 	# Array[String]
 # only used for information
 var incompatibilities := [] 			# Array[String]
 var tags := [] 						# Array[String]
+var config_defaults := []           # Array[String]
 var description_rich := ""
 var image: StreamTexture
 
@@ -74,6 +75,7 @@ func _init(manifest: Dictionary) -> void:
 	compatible_game_version = _get_array_from_dict(godot_details, "compatible_game_version")
 	description_rich = _get_string_from_dict(godot_details, "description_rich")
 	tags = _get_array_from_dict(godot_details, "tags")
+	config_defaults = _get_array_from_dict(godot_details, "config_defaults")
 
 	# todo load file named icon.png when loading mods and use here
 #	image StreamTexture


### PR DESCRIPTION
Fixes a few bits where `.mod_manifest` was used instead of `.manifest`

Also fixes the `get_mod_config` func not working. It still needs an update, but this stops it crashing