### PR TITLE
Fix missing logging in mod manifest

### DIFF
--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -56,9 +56,7 @@ static func log_debug_json_print(message: String, json_printable, mod_name: Stri
 
 
 static func _loader_log(message: String, mod_name: String, log_type: String = "info") -> void:
-	var ignored_arg := get_cmd_line_arg_value("--log-ignore")
-	var ignored_names: Array = str2var(ignored_arg)
-	if ignored_names and mod_name in ignored_names:
+	if is_mod_name_ignored(mod_name):
 		return
 
 	var date := "%s   " % get_date_time_string()
@@ -87,6 +85,16 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 			if _get_verbosity() >= verbosity_level.DEBUG:
 				print(prefix + message)
 				_write_to_log_file(log_message)
+
+
+static func is_mod_name_ignored(mod_name: String) -> bool:
+	var ignored_arg := get_cmd_line_arg_value("--log-ignore")
+
+	if not ignored_arg == "":
+		var ignored_names: Array = ignored_arg.split(",")
+		if mod_name in ignored_names:
+			return true
+	return false
 
 
 static func _write_to_log_file(log_entry: String) -> void:

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -2,6 +2,7 @@ extends Resource
 # Stores and validates contents of the manifest set by the user
 class_name ModManifest
 
+const LOG_NAME := "ModLoader:ModManifest"
 
 # Mod name.
 # Validated by [method is_name_or_namespace_valid]
@@ -95,7 +96,7 @@ func get_package_id() -> String:
 
 # A valid namespace may only use letters (any case), numbers and underscores
 # and has to be longer than 3 characters
-# /^[a-zA-Z0-9_]{3,}$/
+# a-z A-Z 0-9 _ (longer than 3 characters)
 static func is_name_or_namespace_valid(name: String) -> bool:
 	var re := RegEx.new()
 	re.compile("^[a-zA-Z0-9_]*$") # alphanumeric and _
@@ -114,14 +115,22 @@ static func is_name_or_namespace_valid(name: String) -> bool:
 
 # A valid semantic version should follow this format: {mayor}.{minor}.{patch}
 # reference https://semver.org/ for details
-# /^[0-9]+\\.[0-9]+\\.[0-9]+$/
+# {0-9}.{0-9}.{0-9} (no leading 0, shorter than 16 characters total)
 static func is_semver_valid(version_number: String) -> bool:
 	var re := RegEx.new()
-	re.compile("^[0-9]+\\.[0-9]+\\.[0-9]+$")
+	re.compile("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")
 
 	if re.search(version_number) == null:
-		printerr('Invalid semantic version: "%s". ' +
-		'You may only use numbers and periods in this format {mayor}.{minor}.{patch}' % version_number)
+		ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
+			'You may only use numbers without leading zero and periods following this format {mayor}.{minor}.{patch}' % version_number,
+			LOG_NAME
+		)
+		return false
+
+	if version_number.length() > 16:
+		ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
+			'Version number must be shorter than 16 characters.', LOG_NAME
+		)
 		return false
 
 	return true

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -102,12 +102,12 @@ static func is_name_or_namespace_valid(name: String) -> bool:
 	re.compile("^[a-zA-Z0-9_]*$") # alphanumeric and _
 
 	if re.search(name) == null:
-		printerr('Invalid name or namespace: "%s". You may only use letters, numbers and underscores.' % name)
+		ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". You may only use letters, numbers and underscores.' % name, LOG_NAME)
 		return false
 
 	re.compile("^[a-zA-Z0-9_]{3,}$") # at least 3 long
 	if re.search(name) == null:
-		printerr('Invalid name or namespace: "%s". Must be longer than 3 characters.' % name)
+		ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". Must be longer than 3 characters.' % name, LOG_NAME)
 		return false
 
 	return true
@@ -160,7 +160,7 @@ static func dict_has_fields(dict: Dictionary, required_fields: Array) -> bool:
 			missing_fields.erase(key)
 
 	if missing_fields.size() > 0:
-		printerr("Mod data is missing required fields: " + str(missing_fields))
+		ModLoaderUtils.log_fatal("Mod manifest is missing required fields: %s" % missing_fields, LOG_NAME)
 		return false
 
 	return true


### PR DESCRIPTION
Used log_fatal everywhere because the mod won't be loaded with these things being invalid. Avoids missing the error in the console and wondering why the mod did not load