### PR TITLE
Add overwrite functionality

### DIFF
--- a/addons/mod_loader/mod_data.gd
+++ b/addons/mod_loader/mod_data.gd
@@ -14,12 +14,18 @@ enum required_mod_files {
 	MANIFEST,
 }
 
+enum optional_mod_files {
+	OVERWRITES
+}
+
 # Directory of the mod. Has to be identical to [method ModManifest.get_mod_id]
 var dir_name := ""
 # Path to the Mod's Directory
 var dir_path := ""
 # False if any data is invalid
 var is_loadable := true
+# True if overwrites.gd exists
+var is_overwrite := false
 # Is increased for every mod depending on this mod. Highest importance is loaded first
 var importance := 0
 # Contents of the manifest
@@ -95,6 +101,11 @@ func get_required_mod_file_path(required_file: int) -> String:
 			return dir_path.plus_file("manifest.json")
 	return ""
 
+func get_optional_mod_file_path(optional_file: int) -> String:
+	match optional_file:
+		optional_mod_files.OVERWRITES:
+			return dir_path.plus_file("overwrites.gd")
+	return ""
 
 #func _to_string() -> String:
 	# todo if we want it pretty printed

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -403,7 +403,6 @@ func _compare_importance(a: ModData, b: ModData) -> bool:
 
 # Instance every mod and add it as a node to the Mod Loader.
 # Runs mods in the order stored in mod_load_order.
-
 func _init_mod(mod: ModData):
 	var mod_main_path := mod.get_required_mod_file_path(ModData.required_mod_files.MOD_MAIN)
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
@@ -414,7 +413,6 @@ func _init_mod(mod: ModData):
 		var mod_overwrites_script := load(mod_overwrites_path)
 		mod_overwrites_script.new()
 		ModLoaderUtils.log_debug("Initialized overwrite script -> %s" % mod_overwrites_path, LOG_NAME)
-
 
 	ModLoaderUtils.log_debug("Loading script from -> %s" % mod_main_path, LOG_NAME)
 	var mod_main_script := ResourceLoader.load(mod_main_path)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -403,7 +403,7 @@ func _compare_importance(a: ModData, b: ModData) -> bool:
 
 # Instance every mod and add it as a node to the Mod Loader.
 # Runs mods in the order stored in mod_load_order.
-func _init_mod(mod: ModData):
+func _init_mod(mod: ModData) -> void:
 	var mod_main_path := mod.get_required_mod_file_path(ModData.required_mod_files.MOD_MAIN)
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -146,7 +146,7 @@ func _init():
 		mod = mod as ModData
 		ModLoaderUtils.log_debug("mod_load_order -> %s) %s" % [mod_i, mod.dir_name], LOG_NAME)
 		mod_i += 1
-	
+
 	# Instance every mod and add it as a node to the Mod Loader
 	for mod in mod_load_order:
 		ModLoaderUtils.log_info("Initializing -> %s" % mod.manifest.get_mod_id(), LOG_NAME)
@@ -326,8 +326,8 @@ func _init_mod_data(mod_folder_path):
 
 	var mod := ModData.new(local_mod_path)
 	mod.dir_name = dir_name
-	var mod_overwrites_path = mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
-	mod.is_overwrite = ModLoaderUtils.is_file_existing(mod_overwrites_path)
+	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
+	mod.is_overwrite = ModLoaderUtils.file_exists(mod_overwrites_path)
 	mod_data[dir_name] = mod
 
 	# Get the mod file paths
@@ -337,6 +337,7 @@ func _init_mod_data(mod_folder_path):
 	# which has ~1,000 files). That's why it's disabled by default
 	if DEBUG_ENABLE_STORING_FILEPATHS:
 		mod.file_paths = ModLoaderUtils.get_flat_view_dict(local_mod_path)
+
 
 # Run dependency checks on a mod, checking any dependencies it lists in its
 # mod_manifest (ie. its manifest.json file). If a mod depends on another mod that
@@ -405,15 +406,15 @@ func _compare_importance(a, b):
 # Runs mods in the order stored in mod_load_order.
 func _init_mod(mod: ModData):
 	var mod_main_path = mod.get_required_mod_file_path(ModData.required_mod_files.MOD_MAIN)
-	var mod_overwrites_path = mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
-	
+	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
+
 	# If the mod contains overwrites initialize the overwrites script
-	if(mod.is_overwrite):
+	if mod.is_overwrite:
 		ModLoaderUtils.log_debug("Overwrite script detected -> %s" % mod_overwrites_path, LOG_NAME)
-		var mod_overwrites_script = load(mod_overwrites_path)
+		var mod_overwrites_script := load(mod_overwrites_path)
 		mod_overwrites_script.new()
 		ModLoaderUtils.log_debug("Initialized overwrite script -> %s" % mod_overwrites_path, LOG_NAME)
-	
+
 	ModLoaderUtils.log_debug("Loading script from -> %s" % mod_main_path, LOG_NAME)
 	var mod_main_script = ResourceLoader.load(mod_main_path)
 	ModLoaderUtils.log_debug("Loaded script -> %s" % mod_main_script, LOG_NAME)

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -222,6 +222,13 @@ static func get_json_string_as_dict(string: String) -> Dictionary:
 		return {}
 	return parsed.result
 
+static func is_file_existing(path: String) -> bool:
+	var file = File.new()
+	return file.file_exists(path)
+
+static func is_dir_existing(path: String) -> bool:
+	var dir = Directory.new()
+	return dir.dir_exists(path)
 
 # Get a flat array of all files in the target directory. This was needed in the
 # original version of this script, before becoming deprecated. It may still be

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -222,13 +222,16 @@ static func get_json_string_as_dict(string: String) -> Dictionary:
 		return {}
 	return parsed.result
 
+
 static func file_exists(path: String) -> bool:
 	var file = File.new()
 	return file.file_exists(path)
 
+
 static func dir_exists(path: String) -> bool:
 	var dir = Directory.new()
 	return dir.dir_exists(path)
+
 
 # Get a flat array of all files in the target directory. This was needed in the
 # original version of this script, before becoming deprecated. It may still be

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -222,11 +222,11 @@ static func get_json_string_as_dict(string: String) -> Dictionary:
 		return {}
 	return parsed.result
 
-static func is_file_existing(path: String) -> bool:
+static func file_exists(path: String) -> bool:
 	var file = File.new()
 	return file.file_exists(path)
 
-static func is_dir_existing(path: String) -> bool:
+static func dir_exists(path: String) -> bool:
 	var dir = Directory.new()
 	return dir.dir_exists(path)
 


### PR DESCRIPTION
**Let mod authors create the ``overwrites.gd`` at the root of the mod folder**

- My current proposed solution on how to handle the overwrites
- Mod authors create the ``overwrites.gd`` script and ``overwrites`` folder in there mod folder:
![image](https://user-images.githubusercontent.com/41547570/213876012-6eb574e7-1b41-49c8-b214-c9a6ddd91411.png)
- We provide tooling to make the creation of the ``overwrites.gd`` script a one click thing
   - Tooling will be developed in the [Mod Tools Repo](https://github.com/GodotModding/godot-mod-tools)
- People ho don't want to use extra tooling can just write the ``overwrites.gd`` them self

``overwrites.gd`` from example mod:
```python
extends Node

func _init():
	var overwrite_0 = preload("res://mods-unpacked/KANA-OverwritesTest/overwrites/assets/images/GodotModded.png")
	overwrite_0.take_over_path("res://assets/images/GodotModded.png")
```

**Example Mod with this setup:**
[KANA-OverwritesTest.zip](https://github.com/GodotModding/godot-mod-loader/files/10472488/KANA-OverwritesTest.zip)

**Testing Godot Project**
( does not include the Mod Loader - pls use this PR to test )
[ModdingTest.zip](https://github.com/GodotModding/godot-mod-loader/files/10472559/ModdingTest.zip)

closes #14 