### PR TITLE
Fix typo with `modloaderutils`

### DIFF
--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -74,7 +74,7 @@ func setup_modloader() -> void:
 	# Set this here and check it elsewhere to prompt the user for a restart
 	ProjectSettings.set_setting(settings.IS_LOADER_SETUP_APPLIED, false)
 
-	ProjectSettings.save_custom(ModLoaderUtils.get_override_path())
+	ProjectSettings.save_custom(modloaderutils.get_override_path())
 	modloaderutils.log_info("ModLoader setup complete", LOG_NAME)
 
 


### PR DESCRIPTION
Fixes a fatal typo, where `modloaderutils` was written as `ModLoaderUtils`.