### PR TITLE
Validate dependencies and incompatibilities

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -374,7 +374,7 @@ func _check_dependencies(mod: ModData) -> void:
 func _handle_missing_dependency(mod_dir_name: String, dependency_id: String) -> void:
 	ModLoaderUtils.log_error("Missing dependency - mod: -> %s dependency -> %s" % [mod_dir_name, dependency_id], LOG_NAME)
 	# if mod is not present in the missing dependencies array
-	if mod_missing_dependencies.has(mod_dir_name):
+	if not mod_missing_dependencies.has(mod_dir_name):
 		# add it
 		mod_missing_dependencies[mod_dir_name] = []
 

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -146,11 +146,11 @@ static func validate_dependencies_and_incompatibilities(mod_id: String, dependen
 
 	if dependencies.size() > 0:
 		for dep in dependencies:
-			valid_dep = is_dependency_or_incompatibility_valid(mod_id, dep, "dependency")
+			valid_dep = is_mod_id_valid(mod_id, dep, "dependency")
 
 	if incompatibilities.size() > 0:
 		for inc in incompatibilities:
-			valid_inc = is_dependency_or_incompatibility_valid(mod_id, inc, "incompatibility")
+			valid_inc = is_mod_id_valid(mod_id, inc, "incompatibility")
 
 	if not valid_dep or not valid_inc:
 		return false
@@ -158,8 +158,8 @@ static func validate_dependencies_and_incompatibilities(mod_id: String, dependen
 	return true
 
 
-static func is_dependency_or_incompatibility_valid(original_mod_id: String, check_mod_id: String, type: String) -> bool:
-	var intro_text = "A %s for the mod '%s' is invalid: " % [type, original_mod_id]
+static func is_mod_id_valid(original_mod_id: String, check_mod_id: String, type := "") -> bool:
+	var intro_text = "A %s for the mod '%s' is invalid: " % [type, original_mod_id] if not type == "" else ""
 
 	# contains hyphen?
 	if not check_mod_id.count("-") == 1:

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -78,7 +78,7 @@ func _init(manifest: Dictionary) -> void:
 	tags = _get_array_from_dict(godot_details, "tags")
 	config_defaults = godot_details.config_defaults
 
-	var mod_id = str(namespace, "-", name)
+	var mod_id = get_mod_id()
 	if not validate_dependencies_and_incompatibilities(mod_id, dependencies, incompatibilities):
 		return
 


### PR DESCRIPTION
Validates dependencies and incompatibilities, checking the following for any specified mod IDs:

- Contains one `-`
- At least 7 characters (since both name and namespace must be 3+ characters)
- Name & namespace have valid names (via the regex in #60)

Closes #23