### PR TITLE
Add version constant

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -1,7 +1,5 @@
 # ModLoader - A mod loader for GDScript
 #
-# Version 2.0.0
-#
 # Written in 2021 by harrygiel <harrygiel@gmail.com>,
 # in 2021 by Mariusz Chwalba <mariusz@chwalba.net>,
 # in 2022 by Vladimir Panteleev <git@cy.md>,

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -26,6 +26,8 @@ extends Node
 # Most of these settings should never need to change, aside from the DEBUG_*
 # options (which should be `false` when distributing compiled PCKs)
 
+const MODLOADER_VERSION = "4.2.0"
+
 # If true, a complete array of filepaths is stored for each mod. This is
 # disabled by default because the operation can be very expensive, but may
 # be useful for debugging


### PR DESCRIPTION
Adds a constant called `MODLOADER_VERSION` to the main file, *mod_loader.gd*.

Also removes the docs that listed the old version. This new constant can be the single source of truth.

I've set it to `4.2.0`. The next release might not be 4.2 exactly, but I think it's important to have the version higher than the last release from `main` so that if you download from develop, you can easily tell the difference as you'll be on a version that's not the last release version.