### PR TITLE
Assert modlaoder is first autoload

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -167,14 +167,14 @@ func _init() -> void:
 func _check_first_autoload() -> void:
 	var autoloads := {}
 	var autoload_index = 0
-	var modloader_is_first = false
+	var is_mod_loader_first = false
 
 	for prop in ProjectSettings.get_property_list():
 		var name: String = prop.name
 		if name.begins_with("autoload/"):
 			if autoload_index == 0:
 				if name == "autoload/ModLoader":
-					modloader_is_first = true
+					is_mod_loader_first = true
 			var value: String = ProjectSettings.get_setting(name)
 			autoloads[name] = value
 			autoload_index += 1
@@ -190,7 +190,7 @@ func _check_first_autoload() -> void:
 	else:
 		help_msg = "If you're seeing this error, something must have gone wrong in the setup process."
 
-	if not modloader_is_first:
+	if not is_mod_loader_first:
 		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % name, help_msg), LOG_NAME)
 
 	if autoloads.size() == 0:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -86,6 +86,9 @@ func _init() -> void:
 	if REQUIRE_CMD_LINE and not ModLoaderUtils.is_running_with_command_line_arg("--enable-mods"):
 		return
 
+	# Ensure ModLoader is the first autoload
+	_check_first_autoload()
+
 	# Log game install dir
 	ModLoaderUtils.log_info("game_install_directory: %s" % ModLoaderUtils.get_local_folder_dir(), LOG_NAME)
 
@@ -158,6 +161,40 @@ func _init() -> void:
 	ModLoaderUtils.log_debug_json_print("mod data", mod_data, LOG_NAME)
 
 	ModLoaderUtils.log_success("DONE: Completely finished loading mods", LOG_NAME)
+
+
+# Ensure ModLoader is the first autoload
+func _check_first_autoload() -> void:
+	var autoloads := {}
+	var autoload_index = 0
+	var modloader_is_first = false
+
+	for prop in ProjectSettings.get_property_list():
+		var name: String = prop.name
+		if name.begins_with("autoload/"):
+			if autoload_index == 0:
+				if name == "autoload/ModLoader":
+					modloader_is_first = true
+			var value: String = ProjectSettings.get_setting(name)
+			autoloads[name] = value
+			autoload_index += 1
+
+	# Log the autoloads order. Might seem superflous but could help when providing support
+	ModLoaderUtils.log_debug_json_print("Autoload order", autoloads, LOG_NAME)
+
+	var base_msg = "ModLoader needs to be the first autoload to work correctly, "
+	var help_msg = ""
+
+	if OS.has_feature("editor"):
+		help_msg = "To configure your autoloads, to go Project > Project Settings > Autoload, and add ModLoader as the first item. For more info, see the 'Godot Project Setup' page on the ModLoader GitHub wiki."
+	else:
+		help_msg = "If you're seeing this error, something must have gone wrong in the setup process."
+
+	if not modloader_is_first:
+		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % name, help_msg), LOG_NAME)
+
+	if autoloads.size() == 0:
+		ModLoaderUtils.log_fatal(str(base_msg, "but no autoloads are currently set up. ", help_msg), LOG_NAME)
 
 
 # Loop over "res://mods" and add any mod zips to the unpacked virtual directory


### PR DESCRIPTION
Asserts that ModLoader is the first autoload. 

The error messages aim to be as helpful as possible, and change depending on if you're in the editor or not.

Also logs the autoloads, via code by @KANAjetzt (originally from his PR #81).

Closes #87