### PR TITLE
--setup-create-override-cfg cli arg

### DIFF
--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -37,6 +37,7 @@ var file_name := {}
 var is_only_setup: bool = modloaderutils.is_running_with_command_line_arg("--only-setup")
 
 
+
 func _init() -> void:
 	try_setup_modloader()
 	var _changescene_error: int = change_scene(ProjectSettings.get_setting("application/run/main_scene"))


### PR DESCRIPTION
Adds cmd arg:

###  --setup-create-override-cfg
Forces the setup to create the ``override.cfg`` in the game base directory.
Skips the ``project.binary`` injection.

   
   
The project binary injection is skipped in that case.
```python
	if is_setup_create_override_cfg:
		handle_override_cfg()
	else:
		handle_project_binary()
```