### PR TITLE
--setup-create-override-cfg cli arg

### DIFF
--- a/addons/mod_loader/mod_data.gd
+++ b/addons/mod_loader/mod_data.gd
@@ -6,6 +6,11 @@ class_name ModData
 
 const LOG_NAME := "ModLoader:ModData"
 
+# Controls how manifest.json data is logged for each mod
+# true  = Full JSON contents (floods the log)
+# false = Single line (default)
+const USE_EXTENDED_DEBUGLOG := false
+
 # These 2 files are always required by mods.
 # [i]mod_main.gd[/i] = The main init file for the mod
 # [i]manifest.json[/i] = Meta data for the mod, including its dependencies
@@ -51,7 +56,11 @@ func load_manifest() -> void:
 	# Load meta data file
 	var manifest_path := get_required_mod_file_path(required_mod_files.MANIFEST)
 	var manifest_dict := ModLoaderUtils.get_json_as_dict(manifest_path)
-	ModLoaderUtils.log_debug_json_print("%s loaded manifest data -> " % dir_name, manifest_dict, LOG_NAME)
+
+	if USE_EXTENDED_DEBUGLOG:
+		ModLoaderUtils.log_debug_json_print("%s loaded manifest data -> " % dir_name, manifest_dict, LOG_NAME)
+	else:
+		ModLoaderUtils.log_debug(str("%s loaded manifest data -> " % dir_name, manifest_dict), LOG_NAME)
 
 	var mod_manifest := ModManifest.new(manifest_dict)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -6,7 +6,7 @@
 # in 2023 by KANA <kai@kana.jetzt>,
 # in 2023 by Darkly77,
 # in 2023 by otDan <otdanofficial@gmail.com>,
-# in 2023 by Qubus0
+# in 2023 by Qubus0/Ste
 #
 # To the extent possible under law, the author(s) have
 # dedicated all copyright and related and neighboring
@@ -85,6 +85,9 @@ func _init() -> void:
 	# if mods are not enabled - don't load mods
 	if REQUIRE_CMD_LINE and not ModLoaderUtils.is_running_with_command_line_arg("--enable-mods"):
 		return
+
+	# Rotate the log files once on startup. Can't be checked in utils, since it's static
+	ModLoaderUtils.rotate_log_file()
 
 	# Ensure ModLoader is the first autoload
 	_check_first_autoload()

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -98,8 +98,6 @@ func setup_modloader() -> void:
 
 	modloaderutils.log_info("ModLoader setup complete", LOG_NAME)
 
-	modloaderutils.log_info("ModLoader setup complete", LOG_NAME)
-
 
 # Reorders the autoloads in the project settings, to get the ModLoader on top.
 func reorder_autoloads() -> void:

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -35,6 +35,7 @@ var modloaderutils: Node = load("res://addons/mod_loader/mod_loader_utils.gd").n
 var path := {}
 var file_name := {}
 var is_only_setup: bool = modloaderutils.is_running_with_command_line_arg("--only-setup")
+var is_setup_create_override_cfg : bool = modloaderutils.is_running_with_command_line_arg("--setup-create-override-cfg")
 
 
 func _init() -> void:
@@ -58,7 +59,11 @@ func try_setup_modloader() -> void:
 	if is_loader_set_up() and not is_loader_setup_applied():
 		modloaderutils.log_info("ModLoader is set up, but the game needs to be restarted", LOG_NAME)
 		ProjectSettings.set_setting(settings.IS_LOADER_SETUP_APPLIED, true)
-		var _savecustom_error: int = ProjectSettings.save_custom(modloaderutils.get_override_path())
+
+		if is_setup_create_override_cfg:
+			handle_override_cfg()
+		else:
+			handle_project_binary()
 
 		match true:
 			# If the --only-setup cli argument is passed, quit with exit code 0
@@ -82,16 +87,18 @@ func setup_modloader() -> void:
 	reorder_autoloads()
 	ProjectSettings.set_setting(settings.IS_LOADER_SET_UP, true)
 
-	# The game needs to be restarted first, bofore the loader is truly set up
+	# The game needs to be restarted first, before the loader is truly set up
 	# Set this here and check it elsewhere to prompt the user for a restart
 	ProjectSettings.set_setting(settings.IS_LOADER_SETUP_APPLIED, false)
 
-	var _savecustom_error: int = ProjectSettings.save_custom(modloaderutils.get_override_path())
+	if is_setup_create_override_cfg:
+		handle_override_cfg()
+	else:
+		handle_project_binary()
+
 	modloaderutils.log_info("ModLoader setup complete", LOG_NAME)
 
-	create_project_binary()
-	inject_project_binary()
-	clean_up_project_binary_file()
+	modloaderutils.log_info("ModLoader setup complete", LOG_NAME)
 
 
 # Reorders the autoloads in the project settings, to get the ModLoader on top.
@@ -113,6 +120,18 @@ func reorder_autoloads() -> void:
 	# add all previous autoloads back again
 	for autoload in original_autoloads.keys():
 			ProjectSettings.set_setting(autoload, original_autoloads[autoload])
+
+
+# Saves the ProjectSettings to a override.cfg file in the base game directory.
+func handle_override_cfg() -> void:
+	var _save_custom_error: int = ProjectSettings.save_custom(modloaderutils.get_override_path())
+
+
+# Creates the project.binary file, adds it to the pck and removes the no longer needed project.binary file.
+func handle_project_binary() -> void:
+	create_project_binary()
+	inject_project_binary()
+	clean_up_project_binary_file()
 
 
 # Saves the project settings to a project.binary file inside the addons/mod_loader/ directory.

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -65,6 +65,7 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 
 	match log_type.to_lower():
 		"fatal-error":
+			push_error(message)
 			_write_to_log_file(log_message)
 			_write_to_log_file(JSON.print(get_stack(), "  "))
 			assert(false, message)


### PR DESCRIPTION
Adds cmd arg:

###  --setup-create-override-cfg
Forces the setup to create the ``override.cfg`` in the game base directory.
Skips the ``project.binary`` injection.

   
   
The project binary injection is skipped in that case.
```python
	if is_setup_create_override_cfg:
		handle_override_cfg()
	else:
		handle_project_binary()
```