### PR TITLE
`log_fatal` - add the missing log to file

### DIFF
--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -65,6 +65,7 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 
 	match log_type.to_lower():
 		"fatal-error":
+			push_error(message)
 			_write_to_log_file(log_message)
 			_write_to_log_file(JSON.print(get_stack(), "  "))
 			assert(false, message)


### PR DESCRIPTION
Currently `log_fatal` does not log to the file, which means it doesn't get added to *godot.log* during mod development.

Note: The current `"error"` condition uses both `printerr` and `push_error`. But I've only added `push_error` to the `"fatal-error"` condition, because `push_error` seems to print the error by itself (including the `ERROR: ` prefix), making the use of `printerr` redundant. So we may want to remove `printerr` for the `"error"` condition too after this.