### PR TITLE
Utils for ModLoader autoload position

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -169,7 +169,7 @@ func _init() -> void:
 # Ensure ModLoader is the first autoload
 func _check_first_autoload() -> void:
 	var autoload_array = ModLoaderUtils.get_autoload_array()
-	var is_mod_loader_first = autoload_array.find("autoload/ModLoader") == 0
+	var is_mod_loader_first = autoload_array.find("ModLoader") == 0
 
 	var base_msg = "ModLoader needs to be the first autoload to work correctly, "
 	var help_msg = ""
@@ -183,7 +183,7 @@ func _check_first_autoload() -> void:
 		help_msg = "If you're seeing this error, something must have gone wrong in the setup process."
 
 	if not is_mod_loader_first:
-		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % autoload_array[0].trim_prefix("autoload/"), help_msg), LOG_NAME)
+		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % autoload_array[0], help_msg), LOG_NAME)
 
 	if autoload_array.size() == 0:
 		ModLoaderUtils.log_fatal(str(base_msg, "but no autoloads are currently set up. ", help_msg), LOG_NAME)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -168,22 +168,8 @@ func _init() -> void:
 
 # Ensure ModLoader is the first autoload
 func _check_first_autoload() -> void:
-	var autoloads := {}
-	var autoload_index = 0
-	var is_mod_loader_first = false
-
-	for prop in ProjectSettings.get_property_list():
-		var name: String = prop.name
-		if name.begins_with("autoload/"):
-			if autoload_index == 0:
-				if name == "autoload/ModLoader":
-					is_mod_loader_first = true
-			var value: String = ProjectSettings.get_setting(name)
-			autoloads[name] = value
-			autoload_index += 1
-
-	# Log the autoloads order. Might seem superflous but could help when providing support
-	ModLoaderUtils.log_debug_json_print("Autoload order", autoloads, LOG_NAME)
+	var autoload_array = ModLoaderUtils.get_autoload_array()
+	var is_mod_loader_first = autoload_array.find("autoload/ModLoader") == 0
 
 	var base_msg = "ModLoader needs to be the first autoload to work correctly, "
 	var help_msg = ""
@@ -194,9 +180,9 @@ func _check_first_autoload() -> void:
 		help_msg = "If you're seeing this error, something must have gone wrong in the setup process."
 
 	if not is_mod_loader_first:
-		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % name, help_msg), LOG_NAME)
+		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % autoload_array[0].split('/')[1], help_msg), LOG_NAME)
 
-	if autoloads.size() == 0:
+	if autoload_array.size() == 0:
 		ModLoaderUtils.log_fatal(str(base_msg, "but no autoloads are currently set up. ", help_msg), LOG_NAME)
 
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -183,7 +183,7 @@ func _check_first_autoload() -> void:
 		help_msg = "If you're seeing this error, something must have gone wrong in the setup process."
 
 	if not is_mod_loader_first:
-		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % autoload_array[0].split('/')[1], help_msg), LOG_NAME)
+		ModLoaderUtils.log_fatal(str(base_msg, 'but the first autoload is currently: "%s". ' % autoload_array[0].trim_prefix("autoload/"), help_msg), LOG_NAME)
 
 	if autoload_array.size() == 0:
 		ModLoaderUtils.log_fatal(str(base_msg, "but no autoloads are currently set up. ", help_msg), LOG_NAME)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -174,6 +174,9 @@ func _check_first_autoload() -> void:
 	var base_msg = "ModLoader needs to be the first autoload to work correctly, "
 	var help_msg = ""
 
+	# Log the autoloads order. Might seem superflous but could help when providing support
+	ModLoaderUtils.log_debug_json_print("Autoload order", autoload_array, LOG_NAME)
+
 	if OS.has_feature("editor"):
 		help_msg = "To configure your autoloads, to go Project > Project Settings > Autoload, and add ModLoader as the first item. For more info, see the 'Godot Project Setup' page on the ModLoader GitHub wiki."
 	else:

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -350,6 +350,30 @@ static func is_valid_global_class_dict(global_class_dict: Dictionary) -> bool:
 	return true
 
 
+# Get an array of all autoloads -> ["autoload/AutoloadName", ...]
+static func get_autoload_array() -> Array:
+	var autoloads := {}
+
+	# Get all autoload settings
+	for prop in ProjectSettings.get_property_list():
+		var name: String = prop.name
+		if name.begins_with("autoload/"):
+			var value: String = ProjectSettings.get_setting(name)
+			autoloads[name] = value
+
+	var autoload_keys := autoloads.keys()
+
+	return autoload_keys
+
+
+# Get the index of a specific autoload
+static func get_autoload_index(autoload_name: String) -> int:
+	var autoloads := get_autoload_array()
+	var autoload_index := autoloads.find("autoload/" + autoload_name)
+
+	return autoload_index
+
+
 # Get a flat array of all files in the target directory. This was needed in the
 # original version of this script, before becoming deprecated. It may still be
 # used if DEBUG_ENABLE_STORING_FILEPATHS is true.

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -358,7 +358,6 @@ static func get_autoload_array() -> Array:
 	for prop in ProjectSettings.get_property_list():
 		var name: String = prop.name
 		if name.begins_with("autoload/"):
-			var value: String = ProjectSettings.get_setting(name)
 			autoloads.append(name.trim_prefix("autoload/"))
 
 	return autoloads

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -359,7 +359,7 @@ static func get_autoload_array() -> Array:
 		var name: String = prop.name
 		if name.begins_with("autoload/"):
 			var value: String = ProjectSettings.get_setting(name)
-			autoloads.append(name)
+			autoloads.append(name.trim_prefix("autoload/"))
 
 	return autoloads
 
@@ -367,7 +367,7 @@ static func get_autoload_array() -> Array:
 # Get the index of a specific autoload
 static func get_autoload_index(autoload_name: String) -> int:
 	var autoloads := get_autoload_array()
-	var autoload_index := autoloads.find("autoload/" + autoload_name)
+	var autoload_index := autoloads.find(autoload_name)
 
 	return autoload_index
 

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -352,18 +352,16 @@ static func is_valid_global_class_dict(global_class_dict: Dictionary) -> bool:
 
 # Get an array of all autoloads -> ["autoload/AutoloadName", ...]
 static func get_autoload_array() -> Array:
-	var autoloads := {}
+	var autoloads := []
 
 	# Get all autoload settings
 	for prop in ProjectSettings.get_property_list():
 		var name: String = prop.name
 		if name.begins_with("autoload/"):
 			var value: String = ProjectSettings.get_setting(name)
-			autoloads[name] = value
+			autoloads.append(name)
 
-	var autoload_keys := autoloads.keys()
-
-	return autoload_keys
+	return autoloads
 
 
 # Get the index of a specific autoload


### PR DESCRIPTION
Adds two functions to ModLoaderUtils so they can be used in `mod_loader.gd` and the setup script.

- `get_autoload_array() -> Array`
Get an array of all autoloads -> ["autoload/AutoloadName", ...]

- `get_autoload_index(autoload_name: String) -> int`
Get the index of a specific autoload



Updates code from #96 to use the new util.

Has to be merged after #99 