### PR TITLE
✔ Load before

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -376,8 +376,17 @@ func _init_mod_data(mod_folder_path: String) -> void:
 # Run dependency checks on a mod, checking any dependencies it lists in its
 # mod_manifest (ie. its manifest.json file). If a mod depends on another mod that
 # hasn't been loaded, the dependent mod won't be loaded.
-func _check_dependencies(mod: ModData) -> void:
+func _check_dependencies(mod: ModData, dependency_chain_start := '') -> void:
 	ModLoaderUtils.log_debug("Checking dependencies - mod_id: %s dependencies: %s" % [mod.dir_name, mod.manifest.dependencies], LOG_NAME)
+
+	# Check for circular dependency
+	if dependency_chain_start == mod.dir_path:
+		ModLoaderUtils.log_debug("Dependency check - circular dependency detected.", LOG_NAME)
+		return
+
+	# Set dependency_chain_start to the first mod id
+	if dependency_chain_start == '':
+		dependency_chain_start = mod.dir_path
 
 	# loop through each dependency
 	for dependency_id in mod.manifest.dependencies:
@@ -396,7 +405,7 @@ func _check_dependencies(mod: ModData) -> void:
 
 		# check if dependency has dependencies
 		if dependency.manifest.dependencies.size() > 0:
-			_check_dependencies(dependency)
+			_check_dependencies(dependency, dependency_chain_start)
 
 
 # Handle missing dependencies: Sets `is_loadable` to false and logs an error

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -137,6 +137,15 @@ func _init() -> void:
 
 	ModLoaderUtils.log_success("DONE: Loaded all meta data", LOG_NAME)
 
+	# Check for mods with load_before. If a mod is listed in load_before,
+	# add the current mod to the dependencies of the the mod specified
+	# in load_before.
+	for dir_name in mod_data:
+		var mod: ModData = mod_data[dir_name]
+		if not mod.is_loadable:
+			continue
+		_check_load_before(mod)
+
 	# Run dependency checks after loading mod_manifest. If a mod depends on another
 	# mod that hasn't been loaded, that dependent mod won't be loaded.
 	for dir_name in mod_data:
@@ -144,13 +153,6 @@ func _init() -> void:
 		if not mod.is_loadable:
 			continue
 		_check_dependencies(mod)
-
-	# Check for mods with load_before
-	for dir_name in mod_data:
-		var mod: ModData = mod_data[dir_name]
-		if not mod.is_loadable:
-			continue
-		_check_load_before(mod)
 
 	# Sort mod_load_order by the importance score of the mod
 	mod_load_order = _get_load_order(mod_data.values())
@@ -427,28 +429,20 @@ func _handle_missing_dependency(mod_dir_name: String, dependency_id: String) -> 
 
 
 # Run load before check on a mod, checking any load_before entries it lists in its
-# mod_manifest (ie. its manifest.json file). If one entry has a higher importance
-# then the mod, the mods importance score will be set to the importance of the
-# entry with the highest importance + 1.
+# mod_manifest (ie. its manifest.json file). Add the mod to the dependency of the
+# mods inside the load_before array.
 func _check_load_before(mod: ModData) -> void:
 	# Skip if no entries in load_before
 	if mod.manifest.load_before.size() == 0:
 		return
 
-	var highest_importance := 0
-
-	# Get highest importance of load_before mods
+	# Add the mod to the dependency arrays
 	for load_before_id in mod.manifest.load_before:
-		# Grab the importance of the specified mod
-		var load_before_mod_importance = mod_data[load_before_id].importance
-		if highest_importance < load_before_mod_importance:
-			highest_importance = load_before_mod_importance
+		var load_before_mod_dependencies = mod_data[load_before_id].manifest.dependencies
+		load_before_mod_dependencies.append(mod.dir_name)
+		mod_data[load_before_id].manifest.dependencies = load_before_mod_dependencies
 
-	# Set the mod to the importance score of the load_before mod with the same or higher importance + 1
-	# If the own importance is not already higher.
-	if mod.importance <= highest_importance:
-		mod.importance = highest_importance + 1
-		ModLoaderUtils.log_debug("Load before detected -> Set importance for %s to %s, it will load before %s" % [mod.dir_name, mod.importance, mod.manifest.load_before], LOG_NAME)
+	ModLoaderUtils.log_debug("Load before detected -> Added %s as dependency for %s" % [mod.dir_name, mod.manifest.load_before], LOG_NAME)
 
 
 # Get the load order of mods, using a custom sorter

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -444,9 +444,9 @@ func _check_load_before(mod: ModData) -> void:
 		if highest_importance < load_before_mod_importance:
 			highest_importance = load_before_mod_importance
 
-	# Set the mod to the importance score of the load_before mod with the highest importance + 1
+	# Set the mod to the importance score of the load_before mod with the same or higher importance + 1
 	# If the own importance is not already higher.
-	if mod.importance < highest_importance:
+	if mod.importance <= highest_importance:
 		mod.importance = highest_importance + 1
 		ModLoaderUtils.log_debug("Load before detected -> Set importance for %s to %s, it will load before %s" % [mod.dir_name, mod.importance, mod.manifest.load_before], LOG_NAME)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -145,6 +145,13 @@ func _init() -> void:
 			continue
 		_check_dependencies(mod)
 
+	# Check for mods with load_before
+	for dir_name in mod_data:
+		var mod: ModData = mod_data[dir_name]
+		if not mod.is_loadable:
+			continue
+		_check_load_before(mod)
+
 	# Sort mod_load_order by the importance score of the mod
 	mod_load_order = _get_load_order(mod_data.values())
 
@@ -417,6 +424,31 @@ func _handle_missing_dependency(mod_dir_name: String, dependency_id: String) -> 
 		mod_missing_dependencies[mod_dir_name] = []
 
 	mod_missing_dependencies[mod_dir_name].append(dependency_id)
+
+
+# Run load before check on a mod, checking any load_before entries it lists in its
+# mod_manifest (ie. its manifest.json file). If one entry has a higher importance
+# then the mod, the mods importance score will be set to the importance of the
+# entry with the highest importance + 1.
+func _check_load_before(mod: ModData) -> void:
+	# Skip if no entries in load_before
+	if mod.manifest.load_before.size() == 0:
+		return
+
+	var highest_importance := 0
+
+	# Get highest importance of load_before mods
+	for load_before_id in mod.manifest.load_before:
+		# Grab the importance of the specified mod
+		var load_before_mod_importance = mod_data[load_before_id].importance
+		if highest_importance < load_before_mod_importance:
+			highest_importance = load_before_mod_importance
+
+	# Set the mod to the importance score of the load_before mod with the highest importance + 1
+	# If the own importance is not already higher.
+	if mod.importance < highest_importance:
+		mod.importance = highest_importance + 1
+		ModLoaderUtils.log_debug("Load before detected -> Set importance for %s to %s, it will load before %s" % [mod.dir_name, mod.importance, mod.manifest.load_before], LOG_NAME)
 
 
 # Get the load order of mods, using a custom sorter

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -536,64 +536,75 @@ func save_scene(modified_scene: Node, scene_path: String) -> void:
 	_saved_objects.append(packed_scene)
 
 
+enum MLConfigStatus {
+	OK,                  # 0 = No errors
+	INVALID_MOD_ID,      # 1 = Invalid mod ID
+	NO_JSON_OK,          # 2 = No custom JSON. File probably does not exist. Defaults will be used if available
+	NO_JSON_INVALID_KEY, # 3 = No custom JSON, and key was invalid when trying to get the default from your manifest defaults (`extra.godot.config_defaults`)
+	INVALID_KEY          # 4 = Invalid key, although config data does exists
+}
+
 # Get the config data for a specific mod. Always returns a dictionary with two
 # keys: `error` and `data`.
 # Data (`data`) is either the full config, or data from a specific key if one was specified.
 # Error (`error`) is 0 if there were no errors, or > 0 if the setting could not be retrieved:
-# 0 = No errors
-# 1 = Invalid mod ID
-# 2 = No custom JSON. File probably does not exist. Defaults will be used if available
-# 3 = No custom JSON, and key was invalid when trying to get the default from your manifest defaults (`extra.godot.config_defaults`)
-# 4 = Invalid key, although config data does exists
 func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dictionary:
-	var error_num := 0
-	var error_msg := ""
+	var status_code = MLConfigStatus.OK
+	var status_msg := ""
 	var data = {} # can be anything
 	var defaults := {}
 
 	# Invalid mod ID
 	if not mod_data.has(mod_dir_name):
-		error_num = 1
-		error_msg = "ERROR - Mod ID was invalid: %s" % mod_dir_name
+		status_code = MLConfigStatus.INVALID_MOD_ID
+		status_msg = "Mod ID was invalid: %s" % mod_dir_name
 
 	# Mod ID is valid
-	if error_num == 0:
+	if status_code == MLConfigStatus.OK:
 		var mod := mod_data[mod_dir_name] as ModData
 		var config_data := mod.config
 		defaults = mod.manifest.config_defaults
 
 		# No custom JSON file
-		if config_data.size() == 0:
-			error_num = 2
-			error_msg = "WARNING - No config file for %s.json." % mod_dir_name
+		if config_data.size() == MLConfigStatus.OK:
+			status_code = MLConfigStatus.NO_JSON_OK
+			var noconfig_msg = "No config file for %s.json. " % mod_dir_name
 			if key == "":
 				data = defaults
-				error_msg += "Using defaults (extra.godot.config_defaults)"
+				status_msg += str(noconfig_msg, "Using defaults (extra.godot.config_defaults)")
 			else:
 				if defaults.has(key):
 					data = defaults[key]
-					error_msg += "Using defaults for key '%s' (extra.godot.config_defaults.%s)" % [key, key]
+					status_msg += str(noconfig_msg, "Using defaults for key '%s' (extra.godot.config_defaults.%s)" % [key, key])
 				else:
-					error_num = 3
-					error_msg += "Requested key '%s' is not present in the defaults (extra.godot.config_defaults.%s)" % [key, key]
+					status_code = MLConfigStatus.NO_JSON_INVALID_KEY
+					status_msg += str(
+						"Could not get the requested data for %s: " % mod_dir_name,
+						"Requested key '%s' is not present in the 'config_defaults' of the mod's manifest.json file (extra.godot.config_defaults.%s). " % [key, key]
+					)
 
 		# JSON file exists
-		if error_num == 0:
+		if status_code == MLConfigStatus.OK:
 			if key == "":
 				data = config_data
 			else:
 				if config_data.has(key):
 					data = config_data[key]
 				else:
-					error_num = 4
-					error_msg = "WARNING - Invalid key '%s' for mod ID: %s" % [key, mod_dir_name]
+					status_code = MLConfigStatus.INVALID_KEY
+					status_msg = "Invalid key '%s' for mod ID: %s" % [key, mod_dir_name]
 
 	# Log if any errors occured
-	if not error_num == 0:
-		ModLoaderUtils.log_debug("Config Error: %s" % error_msg, mod_dir_name)
+	if not status_code == MLConfigStatus.OK:
+		if status_code == MLConfigStatus.NO_JSON_OK:
+			# No user config file exists. Low importance as very likely to trigger
+			ModLoaderUtils.log_debug("Config JSON Notice: %s" % status_msg, mod_dir_name)
+		else:
+			# Code error (eg. invalid mod ID)
+			ModLoaderUtils.log_fatal("Config JSON Error (%s): %s" % [status_code, status_msg], mod_dir_name)
 
 	return {
-		"error": error_num,
-		"error_msg": error_msg,
+		"status_code": status_code,
+		"status_msg": status_msg,
 		"data": data,
 	}

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -23,6 +23,7 @@ var authors: PoolStringArray = []
 var compatible_game_version: PoolStringArray = []
 # only used for information
 var incompatibilities: PoolStringArray = []
+var load_before: PoolStringArray = []
 var tags : PoolStringArray = []
 var config_defaults := {}
 var description_rich := ""
@@ -70,9 +71,10 @@ func _init(manifest: Dictionary) -> void:
 	website_url = manifest.website_url
 	dependencies = manifest.dependencies
 
-	var 	godot_details: Dictionary = manifest.extra.godot
+	var godot_details: Dictionary = manifest.extra.godot
 	authors = _get_array_from_dict(godot_details, "authors")
 	incompatibilities = _get_array_from_dict(godot_details, "incompatibilities")
+	load_before = _get_array_from_dict(godot_details, "load_before")
 	compatible_game_version = _get_array_from_dict(godot_details, "compatible_game_version")
 	description_rich = _get_string_from_dict(godot_details, "description_rich")
 	tags = _get_array_from_dict(godot_details, "tags")


### PR DESCRIPTION
# Load before some mod

Adds functionality to specify a mod you want to load before your own mod. 

Load before field added to  *manifest.json* in *extra* -> *godot* -> *load_before*

For example:
`"load_before": ["Darkly77-ContentLoader"],`

```JSON
{
	"name": "WhatAmILookingAt",
	"namespace": "KANA",
	"version_number": "1.0.0",
	"description": "Tells you where this thing is from.",
	"website_url": "https://github.com/BrotatoMods",
	"dependencies": [],
	"extra": {
		"godot": {
			"incompatibilities": [],
			"load_before": ["Darkly77-ContentLoader"],
			"authors": ["KANA"],
			"compatible_mod_loader_version": "4.3.0",
			"compatible_game_version": ["0.8.0.3"],
			"config_defaults": {}
		}
	}
}
```

Will need some more testing, this is just a naive implementation.

---
closes #114 