### PR TITLE
Inheritance checks for script extensions

### DIFF
--- a/addons/mod_loader/script_extension_data.gd
+++ b/addons/mod_loader/script_extension_data.gd
@@ -1,0 +1,20 @@
+class_name ScriptExtensionData
+extends Resource
+
+# Stores all Data defining a script extension
+
+# Full path to the extension file
+var extension_path:String
+
+# Full path to the vanilla script extended
+var parent_script_path:String
+
+# Mod requesting the extension
+var mod_id:String
+
+
+func _init(p_extension_path:String, p_parent_script_path:String, p_mod_id:String):
+	extension_path = p_extension_path
+	parent_script_path = p_parent_script_path
+	mod_id = p_mod_id
+


### PR DESCRIPTION

The current schema for installing script extensions relies on an importance score for each mod, where the score is equal to how many times a mod appears as a dependency inside the current mod list.
That score is used to let more important mods load before others, and thus let their extensions load before those of other mods.

This layout poses one problem in situations where parent and child scripts in vanilla are supposed to be extended within the same mod list : a mod with bigger importance can look to extend a script that is child to a script extended by mod(s) of lower importance.

This results in the child script not taking into account the changes made by the extension(s) to the parent script.
This is also not a problem that can be solved through mod load order alone, since regardless of the importance score, 2 mods may be faced with this situation twice, with their roles reversed in the second situation.

This PR looks to take into account vanilla's inheritance chain to decide the order in which extensions are installed. The mods' importance scores are still used to load mods following their dependencies.
But in situations where a more important mod would extend a child before their parent, the extension(s) of the parent script is given priority.

Also, even when extending in that order, vanilla parents still get loaded as base scripts when extending a child script, instead of their extended version.
To make sure the extended parents are used when extending child scripts, reload() is called everytime a script is extended
