### PR TITLE
refactor: :recycle: Added is_silent parameter to validation functions

### DIFF
--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -101,17 +101,19 @@ func get_package_id() -> String:
 # A valid namespace may only use letters (any case), numbers and underscores
 # and has to be longer than 3 characters
 # a-z A-Z 0-9 _ (longer than 3 characters)
-static func is_name_or_namespace_valid(check_name: String) -> bool:
+static func is_name_or_namespace_valid(check_name: String, is_silent := false) -> bool:
 	var re := RegEx.new()
 	var _compile_error_1 = re.compile("^[a-zA-Z0-9_]*$") # alphanumeric and _
 
 	if re.search(check_name) == null:
-		ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". You may only use letters, numbers and underscores.' % check_name, LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". You may only use letters, numbers and underscores.' % check_name, LOG_NAME)
 		return false
 
 	var _compile_error_2 = re.compile("^[a-zA-Z0-9_]{3,}$") # at least 3 long
 	if re.search(check_name) == null:
-		ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". Must be longer than 3 characters.' % check_name, LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal('Invalid name or namespace: "%s". Must be longer than 3 characters.' % check_name, LOG_NAME)
 		return false
 
 	return true
@@ -120,37 +122,39 @@ static func is_name_or_namespace_valid(check_name: String) -> bool:
 # A valid semantic version should follow this format: {mayor}.{minor}.{patch}
 # reference https://semver.org/ for details
 # {0-9}.{0-9}.{0-9} (no leading 0, shorter than 16 characters total)
-static func is_semver_valid(check_version_number: String) -> bool:
+static func is_semver_valid(check_version_number: String, is_silent := false) -> bool:
 	var re := RegEx.new()
 	var _compile_error = re.compile("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")
 
 	if re.search(check_version_number) == null:
-		ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
-			'You may only use numbers without leading zero and periods following this format {mayor}.{minor}.{patch}' % check_version_number,
-			LOG_NAME
-		)
+		if not is_silent:
+			ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
+				'You may only use numbers without leading zero and periods following this format {mayor}.{minor}.{patch}' % check_version_number,
+				LOG_NAME
+			)
 		return false
 
 	if check_version_number.length() > 16:
-		ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
-			'Version number must be shorter than 16 characters.', LOG_NAME
-		)
+		if not is_silent:
+			ModLoaderUtils.log_fatal('Invalid semantic version: "%s". ' +
+				'Version number must be shorter than 16 characters.', LOG_NAME
+			)
 		return false
 
 	return true
 
 
-static func validate_dependencies_and_incompatibilities(mod_id: String, dependencies: PoolStringArray, incompatibilities: PoolStringArray) -> bool:
+static func validate_dependencies_and_incompatibilities(mod_id: String, dependencies: PoolStringArray, incompatibilities: PoolStringArray, is_silent := false) -> bool:
 	var valid_dep = true
 	var valid_inc = true
 
 	if dependencies.size() > 0:
 		for dep in dependencies:
-			valid_dep = is_mod_id_valid(mod_id, dep, "dependency")
+			valid_dep = is_mod_id_valid(mod_id, dep, "dependency", is_silent)
 
 	if incompatibilities.size() > 0:
 		for inc in incompatibilities:
-			valid_inc = is_mod_id_valid(mod_id, inc, "incompatibility")
+			valid_inc = is_mod_id_valid(mod_id, inc, "incompatibility", is_silent)
 
 	if not valid_dep or not valid_inc:
 		return false
@@ -158,18 +162,20 @@ static func validate_dependencies_and_incompatibilities(mod_id: String, dependen
 	return true
 
 
-static func is_mod_id_valid(original_mod_id: String, check_mod_id: String, type := "") -> bool:
+static func is_mod_id_valid(original_mod_id: String, check_mod_id: String, type := "", is_silent := false) -> bool:
 	var intro_text = "A %s for the mod '%s' is invalid: " % [type, original_mod_id] if not type == "" else ""
 
 	# contains hyphen?
 	if not check_mod_id.count("-") == 1:
-		ModLoaderUtils.log_fatal(str(intro_text, 'Expected a single hypen in the mod ID, but the %s was: "%s"' % [type, check_mod_id]), LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal(str(intro_text, 'Expected a single hypen in the mod ID, but the %s was: "%s"' % [type, check_mod_id]), LOG_NAME)
 		return false
 
 	# at least 7 long (1 for hyphen, 3 each for namespace/name)
 	var mod_id_length = check_mod_id.length()
 	if mod_id_length < 7:
-		ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID for "%s" is too short. It must be at least 7 characters, but its length is: %s' % [check_mod_id, mod_id_length]), LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID for "%s" is too short. It must be at least 7 characters, but its length is: %s' % [check_mod_id, mod_id_length]), LOG_NAME)
 		return false
 
 	var split = check_mod_id.split("-")
@@ -179,11 +185,13 @@ static func is_mod_id_valid(original_mod_id: String, check_mod_id: String, type 
 	re.compile("^[a-zA-Z0-9_]*$") # alphanumeric and _
 
 	if re.search(check_namespace) == null:
-		ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID has an invalid namespace (author) for "%s". Namespace can only use letters, numbers and underscores, but was: "%s"' % [check_mod_id, check_namespace]), LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID has an invalid namespace (author) for "%s". Namespace can only use letters, numbers and underscores, but was: "%s"' % [check_mod_id, check_namespace]), LOG_NAME)
 		return false
 
 	if re.search(check_name) == null:
-		ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID has an invalid name for "%s". Name can only use letters, numbers and underscores, but was: "%s"' % [check_mod_id, check_name]), LOG_NAME)
+		if not is_silent:
+			ModLoaderUtils.log_fatal(str(intro_text, 'Mod ID has an invalid name for "%s". Name can only use letters, numbers and underscores, but was: "%s"' % [check_mod_id, check_name]), LOG_NAME)
 		return false
 
 	return true


### PR DESCRIPTION
Added is_silent parameter to 

- `is_name_or_namespace_valid()`
- `is_semver_valid()`
- `validate_dependencies_and_incompatibilities()`
- `is_mod_id_valid()`

Can be used to not log an error if the validation returns `false`. Useful for example if the validation is used in a text input where the result will be most of the times `false`. Implemented with the [ModTool](https://github.com/GodotModding/godot-mod-tool) in mind.

**Sorry accidentally closed #128*
