### PR TITLE
Validation: Don't allow mods to include themselves as dependencies or incompatibilities

### DIFF
--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -150,10 +150,14 @@ static func validate_dependencies_and_incompatibilities(mod_id: String, dependen
 
 	if dependencies.size() > 0:
 		for dep in dependencies:
+			if dep == mod_id:
+				ModLoaderUtils.log_fatal("The mod \"%s\" lists itself as a dependency in its own manifest.json file" % mod_id, LOG_NAME)
 			valid_dep = is_mod_id_valid(mod_id, dep, "dependency", is_silent)
 
 	if incompatibilities.size() > 0:
 		for inc in incompatibilities:
+			if inc == mod_id:
+				ModLoaderUtils.log_fatal("The mod \"%s\" lists itself as an incompatible mod in its own manifest.json file" % mod_id, LOG_NAME)
 			valid_inc = is_mod_id_valid(mod_id, inc, "incompatibility", is_silent)
 
 	if not valid_dep or not valid_inc:


### PR DESCRIPTION
Fixes infinite loops if a mod adds itself as a dependency. Also prevents mods from being listed as incompatible with themselves.

![image](https://user-images.githubusercontent.com/43499897/221431145-09a06bad-0274-4091-8c19-5d30846b32c9.png)

![image](https://user-images.githubusercontent.com/43499897/221431136-7743de8d-292e-42ae-ab84-7af7ba7bc908.png)

Closes #113:

- #113