### PR TITLE
Cleanup: Remove todos

### DIFF
--- a/addons/mod_loader/mod_data.gd
+++ b/addons/mod_loader/mod_data.gd
@@ -115,8 +115,3 @@ func get_optional_mod_file_path(optional_file: int) -> String:
 		optional_mod_files.OVERWRITES:
 			return dir_path.plus_file("overwrites.gd")
 	return ""
-
-#func _to_string() -> String:
-	# todo if we want it pretty printed
-
-

--- a/addons/mod_loader/mod_manifest.gd
+++ b/addons/mod_loader/mod_manifest.gd
@@ -82,9 +82,6 @@ func _init(manifest: Dictionary) -> void:
 	if not validate_dependencies_and_incompatibilities(mod_id, dependencies, incompatibilities):
 		return
 
-	# todo load file named icon.png when loading mods and use here
-#	image StreamTexture
-
 
 # Mod ID used in the mod loader
 # Format: {namespace}-{name}
@@ -225,8 +222,3 @@ static func dict_has_fields(dict: Dictionary, required_fields: Array) -> bool:
 		return false
 
 	return true
-
-
-#func _to_json()	-> String:
-#	return ""
-


### PR DESCRIPTION
Removes a few "todo" comments. They'd be better as [issues](https://github.com/GodotModding/godot-mod-loader/issues) if we still want to implement them, as that would help us keep track of them better.