### PR TITLE
Config JSON: Swap status codes 1 and 2 (closes #131)

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -677,9 +677,9 @@ func save_scene(modified_scene: Node, scene_path: String) -> void:
 
 enum MLConfigStatus {
 	OK,                  # 0 = No errors
-	INVALID_MOD_ID,      # 1 = Invalid mod ID
-	NO_JSON_OK,          # 2 = No custom JSON. File probably does not exist. Defaults will be used if available
-	NO_JSON_INVALID_KEY, # 3 = No custom JSON, and key was invalid when trying to get the default from your manifest defaults (`extra.godot.config_defaults`)
+	NO_JSON_OK,          # 1 = No custom JSON (file probably does not exist). Uses defaults from manifest, if available
+	INVALID_MOD_ID,      # 2 = Invalid mod ID
+	NO_JSON_INVALID_KEY, # 3 = Invalid key, and no custom JSON was specified in the manifest defaults (`extra.godot.config_defaults`)
 	INVALID_KEY          # 4 = Invalid key, although config data does exists
 }
 


### PR DESCRIPTION
Swaps the status codes `1` and `2` around, so that a valid code is always `>= 1`. Also has a very minor presentation edit for the comments on the enums.

Closes #131:

- #131