### PR TITLE
Misc: Add `code_note` func, to show a helpful message in `log_fatal`

### DIFF
--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -64,9 +64,11 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 	var log_message := time + prefix + message
 
 	code_note(str(
-		"If you are seeing this, there is an error in your mod somewhere.",
+		"If you are seeing this after trying to run the game, there is an error in your mod somewhere.",
 		"Check the Debugger tab (below) to see the error.",
-		"Click through the files listed in Stack Frames to trace where the error originated."
+		"Click through the files listed in Stack Frames to trace where the error originated.",
+		"View Godot's documentation for more info:",
+		"https://docs.godotengine.org/en/stable/tutorials/scripting/debug/debugger_panel.html#doc-debugger-panel"
 	))
 
 	match log_type.to_lower():

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -63,6 +63,12 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 	var prefix := "%s %s: " % [log_type.to_upper(), mod_name]
 	var log_message := time + prefix + message
 
+	code_note(str(
+		"If you are seeing this, there is an error in your mod somewhere.",
+		"Check the Debugger tab (below) to see the error.",
+		"Click through the files listed in Stack Frames to trace where the error originated."
+	))
+
 	match log_type.to_lower():
 		"fatal-error":
 			push_error(message)
@@ -86,6 +92,13 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 			if _get_verbosity() >= verbosity_level.DEBUG:
 				print(prefix + message)
 				_write_to_log_file(log_message)
+
+
+# This is a dummy func. It is exclusively used to show notes in the code that
+# stay visible after decompiling a PCK, as is primarily intended to assist new
+# modders in understanding and troubleshooting issues
+static func code_note(_msg:String):
+	pass
 
 
 static func is_mod_name_ignored(mod_name: String) -> bool:


### PR DESCRIPTION
I saw this approach in a c# game I decompiled a while ago. It lets us show important notes that would otherwise be stripped when you decompile a game's PCK.

I don't know how useful it would be across the entire codebase, but I think that doing it for this one particular bit of code (`log_fatal`) would be very helpful to new users. Eg. I've seen a few people on the Brotato discord who didn't understand why they were getting an error here, because if you don't know about the error stack trace, it can look like an error with ModLoader itself.

It uses a dummy func, `code_note`, which does nothing but can be re-used elsewhere as it's part of `ModLoaderUtils`.