### PR TITLE
Config JSON: Add API methods for saving data

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -775,7 +775,7 @@ func save_mod_config_dictionary(mod_id: String, data: Dictionary, update_config:
 		return false
 
 	var data_original: Dictionary = config_obj.data
-	var data_new = {}
+	var data_new := {}
 
 	# Merge
 	if update_config:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -759,7 +759,7 @@ func is_mod_config_data_valid(config_obj: Dictionary) -> bool:
 	return config_obj.status_code <= MLConfigStatus.NO_JSON_OK
 
 
-# Saves a full dictionary object to a mod's custon config file, as JSON.
+# Saves a full dictionary object to a mod's custom config file, as JSON.
 # Overwrites any existing data in the file.
 # Optionally updates the config object that's stored in memory (true by default).
 # Returns a bool indicating success or failure.

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -675,6 +675,9 @@ func save_scene(modified_scene: Node, scene_path: String) -> void:
 	_saved_objects.append(packed_scene)
 
 
+# Helpers - Config JSON
+# =============================================================================
+
 enum MLConfigStatus {
 	OK,                  # 0 = No errors
 	NO_JSON_OK,          # 1 = No custom JSON (file probably does not exist). Uses defaults from manifest, if available
@@ -747,3 +750,58 @@ func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dictionary:
 		"status_msg": status_msg,
 		"data": data,
 	}
+
+
+# Returns a bool indicating if a retrieved mod config is valid.
+# Requires the full config object (ie. the dictionary that's returned by
+# `get_mod_config`)
+func is_mod_config_data_valid(config_obj: Dictionary) -> bool:
+	return config_obj.status_code <= MLConfigStatus.NO_JSON_OK
+
+
+# Saves a full dictionary object to a mod's custon config file, as JSON.
+# Overwrites any existing data in the file.
+# Optionally updates the config object that's stored in memory (true by default).
+# Returns a bool indicating success or failure.
+# WARNING: Provides no validation
+func save_mod_config_dictionary(mod_id: String, data: Dictionary, update_config: bool = true) -> bool:
+	# Use `get_mod_config` to check if a custom JSON file already exists.
+	# This has the added benefit of logging a fatal error if mod_name is
+	# invalid (as it already happens in `get_mod_config`)
+	var config_obj := get_mod_config(mod_id)
+
+	if not is_mod_config_data_valid(config_obj):
+		ModLoaderUtils.log_warning("Could not save the config JSON file because the config data was invalid", mod_id)
+		return false
+
+	var data_original: Dictionary = config_obj.data
+	var data_new = {}
+
+	# Merge
+	if update_config:
+		# Update the config held in memory
+		data_original.merge(data, true)
+		data_new = data_original
+	else:
+		# Don't update the config in memory
+		data_new = data_original.duplicate(true)
+		data_new.merge(data, true)
+
+	# Note: This bit of code is duped from `_load_mod_configs`
+	var configs_path := ModLoaderUtils.get_local_folder_dir("configs")
+	if not os_configs_path_override == "":
+		configs_path = os_configs_path_override
+
+	var json_path := configs_path.plus_file(mod_id + ".json")
+
+	return ModLoaderUtils.save_dictionary_to_file(data_new, json_path)
+
+
+# Saves a single settings to a mod's custom config file.
+# Returns a bool indicating success or failure.
+func save_mod_config_setting(mod_id: String, key:String, value, update_config: bool = true) -> bool:
+	var new_data = {
+		key: value
+	}
+
+	return save_mod_config_dictionary(mod_id, new_data, update_config)

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -477,3 +477,38 @@ static func get_flat_view_dict(p_dir := "res://", p_match := "", p_match_is_rege
 			dir.list_dir_end()
 	return data
 
+
+# Saves a dictionary to a file, as a JSON string
+static func save_string_to_file(save_string: String, filepath: String) -> bool:
+	# Create directory if it doesn't exist yet
+	var file_directory := filepath.get_base_dir()
+	var dir := Directory.new()
+	if not dir.dir_exists(file_directory):
+		var makedir_error = dir.make_dir_recursive(file_directory)
+		if not makedir_error == OK:
+			# @todo: Uncomment when PR #139 is merged: https://github.com/GodotModding/godot-mod-loader/pull/139
+			#code_note("View error codes here: https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-error")
+			log_fatal("Encountered an error (%s) when attempting to create a directory, with the path: %s" % [makedir_error, file_directory], LOG_NAME)
+			return false
+
+	var file = File.new()
+
+	# Save data to the file
+	var fileopen_error = file.open(filepath, File.WRITE)
+
+	if not fileopen_error == OK:
+		# @todo: Uncomment when PR #139 is merged: https://github.com/GodotModding/godot-mod-loader/pull/139
+		#code_note("View error codes here: https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#enum-globalscope-error")
+		log_fatal("Encountered an error (%s) when attempting to write to a file, with the path: %s" % [fileopen_error, filepath], LOG_NAME)
+		return false
+
+	file.store_string(save_string)
+	file.close()
+
+	return true
+
+
+# Saves a dictionary to a file, as a JSON string
+static func save_dictionary_to_file(data: Dictionary, filepath: String) -> bool:
+	var json_string = JSON.print(data, "\t")
+	return save_string_to_file(json_string, filepath)


### PR DESCRIPTION
**NOTE: Depends on PR #143, which should be merged first.**

Adds 3 methods to `ModLoader`. There's 2 for saving data, plus a small utility method for checking if a config JSON data object is valid.

```gdscript
# Utility
func is_mod_config_data_valid(config_obj: Dictionary) -> bool:

# Saving
func save_mod_config_dictionary(mod_id: String, data: Dictionary, update_config: bool = true) -> bool:
func save_mod_config_setting(mod_id: String, key:String, value, update_config: bool = true) -> bool:
```

Docs: https://github.com/GodotModding/godot-mod-loader/wiki/Upcoming-Features#config-json

---

Closes #132:

- #132
