### PR TITLE
Refactor: Move `class_name` to be before `extends`

### DIFF
--- a/addons/mod_loader/classes/mod_data.gd
+++ b/addons/mod_loader/classes/mod_data.gd
@@ -1,5 +1,5 @@
-extends Resource
 class_name ModData
+extends Resource
 
 # Stores and validates all Data required to load a mod successfully
 # If some of the data is invalid, [member is_loadable] will be false

--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -1,6 +1,7 @@
-extends Resource
-# Stores and validates contents of the manifest set by the user
 class_name ModManifest
+extends Resource
+
+# Stores and validates contents of the manifest set by the user
 
 const LOG_NAME := "ModLoader:ModManifest"
 

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -1,5 +1,5 @@
-extends Node
 class_name ModLoaderUtils
+extends Node
 
 const LOG_NAME := "ModLoader:ModLoaderUtils"
 const MOD_LOG_PATH := "user://logs/modloader.log"


### PR DESCRIPTION
Moves `class_name` to come before `extends`. This follows Godot's [style guide](https://docs.godotengine.org/en/3.5/tutorials/scripting/gdscript/gdscript_styleguide.html), and makes all our classes follow the same convention.

![image](https://user-images.githubusercontent.com/43499897/222291486-1303bca0-9c27-40d3-88e1-b617f38226b2.png)
