### PR TITLE
API: Add methods for deprecation + API Folder

### DIFF
--- a/addons/mod_loader/api/deprecated.gd
+++ b/addons/mod_loader/api/deprecated.gd
@@ -1,0 +1,34 @@
+class_name ModLoaderDeprecated
+extends Node
+
+# API methods for deprecating funcs. Can be used by mods with public APIs.
+
+const LOG_NAME := "ModLoader:Deprecated"
+
+
+# A method has changed its name/class
+static func deprecated_changed(old_method: String, new_method: String, since_version: String, show_removal_note: bool = true):
+	ModLoaderUtils.log_fatal(str(
+		"DEPRECATED: ",
+		"The method \"%s\" has been deprecated since version %s. " % [old_method, since_version],
+		"Please use \"%s\" instead. " % new_method,
+		"The old method will be removed with the next major update, and will break your code if not changed. " if show_removal_note else ""
+	), LOG_NAME)
+
+
+# A method has been entirely removed, with no replacement
+# (should never be needed but good to have just in case)
+static func deprecated_removed(old_method: String, since_version: String, show_removal_note: bool = true):
+	ModLoaderUtils.log_fatal(str(
+		"DEPRECATED: ",
+		"The method \"%s\" has been deprecated since version %s, and is no longer available. " % [old_method, since_version],
+		"There is currently no replacement method. ",
+		"The method will be removed with the next major update, and will break your code if not changed. " if show_removal_note else ""
+	), LOG_NAME)
+
+
+# Freeform deprecation message.
+# Allows you to add a deprecation comment without specifying the old/new method
+static func deprecated_message(msg: String, since_version: String = ""):
+	var since_text = " (since version %s)" % since_version if not since_version == "" else ""
+	ModLoaderUtils.log_fatal(str("DEPRECATED: ", msg, since_text), LOG_NAME)

--- a/addons/mod_loader/api/deprecated.gd
+++ b/addons/mod_loader/api/deprecated.gd
@@ -30,5 +30,5 @@ static func deprecated_removed(old_method: String, since_version: String, show_r
 # Freeform deprecation message.
 # Allows you to add a deprecation comment without specifying the old/new method
 static func deprecated_message(msg: String, since_version: String = ""):
-	var since_text = " (since version %s)" % since_version if not since_version == "" else ""
+	var since_text := " (since version %s)" % since_version if not since_version == "" else ""
 	ModLoaderUtils.log_fatal(str("DEPRECATED: ", msg, since_text), LOG_NAME)

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -40,6 +40,11 @@ const new_global_classes := [
 		"class": "ModLoaderOptionsProfile",
 		"language": "GDScript",
 		"path": "res://addons/mod_loader/options/classes/options_profile.gd"
+	}, {
+		"base": "Node",
+		"class": "ModLoaderDeprecated",
+		"language": "GDScript",
+		"path": "res://addons/mod_loader/api/deprecated.gd"
 	}
 ]
 


### PR DESCRIPTION
Adds 3 new methods for deprecation, as outlined and discussed in #154, which this PR closes. 

Deviates slightly from #154, in that the deprecation messages are generic, rather than specific to ModLoader. This means that mods can use these methods too, not just ModLoader.

Additionally, this PR introduces the `api` directory, as discussed in #153. Classes in this folder are considered to be available for public use.

### Methods

```gdscript
# A method has changed its name/class
static func deprecated_changed(old_method: String, new_method: String, since_version: String, show_removal_note: bool = true)

# A method has been entirely removed, with no replacement
# (should never be needed but good to have just in case)
static func deprecated_removed(old_method: String, since_version: String, show_removal_note: bool = true)

# Freeform deprecation message.
# Allows you to add a deprecation comment without specifying the old/new method
static func deprecated_message(msg: String, since_version: String = "")
```

### Examples

**Code:**

```gdscript
ModLoaderDeprecated.deprecated_changed("Hello.World", "Hello.Globe", "6.5.0")
ModLoaderDeprecated.deprecated_removed("Hello.World", "6.5.0")
ModLoaderDeprecated.deprecated_message("Generic deprecation message with version", "6.5.0")
ModLoaderDeprecated.deprecated_message("Generic deprecation message, no version")
```

**Results:**

`deprecated_changed`

![deprecated_changed](https://user-images.githubusercontent.com/43499897/222326059-5215ae1e-3876-4c2c-8adb-26bc41b0b2a2.PNG)

`deprecated_removed`

![deprecated_removed](https://user-images.githubusercontent.com/43499897/222326067-18a7edcf-68de-48f0-b08b-19178d575d01.PNG)

`deprecated_message` _(wi. version)_

![deprecated_message1](https://user-images.githubusercontent.com/43499897/222326080-e3fce399-8968-4d91-a83a-1f72c6714dc5.PNG)

`deprecated_message` _(no version)_

![deprecated_message2](https://user-images.githubusercontent.com/43499897/222326086-cd107e1f-1bfd-4afb-816a-39558177c0d9.PNG)

### Related

- #153
- #154