### PR TITLE
feat: ✨ ModLoaderStore: New singleton to store data

### DIFF
--- a/addons/mod_loader/api/config.gd
+++ b/addons/mod_loader/api/config.gd
@@ -70,9 +70,9 @@ static func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dicti
 			# No user config file exists. Low importance as very likely to trigger
 			var full_msg = "Config JSON Notice: %s" % status_msg
 			# Only log this once, to avoid flooding the log
-			if not ModLoaderStore.ml_data.logged_messages.has(full_msg):
+			if not ModLoaderStore.logged_messages.has(full_msg):
 				ModLoaderUtils.log_debug(full_msg, mod_dir_name)
-				ModLoaderStore.ml_data.logged_messages.push_back(full_msg)
+				ModLoaderStore.logged_messages.push_back(full_msg)
 		else:
 			# Code error (eg. invalid mod ID)
 			ModLoaderUtils.log_fatal("Config JSON Error (%s): %s" % [status_code, status_msg], mod_dir_name)

--- a/addons/mod_loader/api/config.gd
+++ b/addons/mod_loader/api/config.gd
@@ -70,9 +70,9 @@ static func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dicti
 			# No user config file exists. Low importance as very likely to trigger
 			var full_msg = "Config JSON Notice: %s" % status_msg
 			# Only log this once, to avoid flooding the log
-			if not ModLoader.logged_messages.has(full_msg):
+			if not ModLoaderStore.ml_data.logged_messages.has(full_msg):
 				ModLoaderUtils.log_debug(full_msg, mod_dir_name)
-				ModLoader.logged_messages.push_back(full_msg)
+				ModLoaderStore.ml_data.logged_messages.push_back(full_msg)
 		else:
 			# Code error (eg. invalid mod ID)
 			ModLoaderUtils.log_fatal("Config JSON Error (%s): %s" % [status_code, status_msg], mod_dir_name)
@@ -119,11 +119,7 @@ static func save_mod_config_dictionary(mod_id: String, data: Dictionary, update_
 		data_new = data_original.duplicate(true)
 		data_new.merge(data, true)
 
-	# Note: This bit of code is duped from `_load_mod_configs`
-	var configs_path := ModLoaderUtils.get_local_folder_dir("configs")
-	if not ModLoader.os_configs_path_override == "":
-		configs_path = ModLoader.os_configs_path_override
-
+	var configs_path := ModLoaderUtils.get_path_to_configs()
 	var json_path := configs_path.plus_file(mod_id + ".json")
 
 	return ModLoaderUtils.save_dictionary_to_json_file(data_new, json_path)

--- a/addons/mod_loader/api/godot.gd
+++ b/addons/mod_loader/api/godot.gd
@@ -1,0 +1,26 @@
+class_name ModLoaderGodot
+extends Object
+
+# API methods for interacting with Godot
+
+const LOG_NAME := "ModLoader:Godot"
+
+
+# Check the index position of the provided autoload (0 = 1st, 1 = 2nd, etc).
+# Returns a bool if the position does not match.
+# Optionally triggers a fatal error
+static func check_autoload_position(autoload_name: String, position_index: int, trigger_error: bool = false) -> bool:
+	var autoload_array := ModLoaderUtils.get_autoload_array()
+	var autoload_index := autoload_array.find(autoload_name)
+	var position_matches := autoload_index == position_index
+
+	if not position_matches and trigger_error:
+		var error_msg := "Expected %s to be the autoload in position %s, but this is currently %s." % [autoload_name, str(position_index + 1), autoload_array[position_index]]
+		var help_msg := ""
+
+		if OS.has_feature("editor"):
+			help_msg = " To configure your autoloads, go to Project > Project Settings > Autoload."
+
+		ModLoaderUtils.log_fatal(error_msg + help_msg, LOG_NAME)
+
+	return position_matches

--- a/addons/mod_loader/api/third_party/steam.gd
+++ b/addons/mod_loader/api/third_party/steam.gd
@@ -15,7 +15,10 @@ const LOG_NAME := "ModLoader:ThirdParty:Steam"
 # Eg. Brotato:
 #   GAME     = Steam/steamapps/common/Brotato
 #   WORKSHOP = Steam/steamapps/workshop/content/1942280
-static func get_steam_workshop_dir() -> String:
+static func get_path_to_workshop() -> String:
+	if ModLoaderStore.ml_options.override_path_to_workshop:
+		return ModLoaderStore.ml_options.override_path_to_workshop
+
 	var game_install_directory := ModLoaderUtils.get_local_folder_dir()
 	var path := ""
 

--- a/addons/mod_loader/classes/options_profile.gd
+++ b/addons/mod_loader/classes/options_profile.gd
@@ -6,9 +6,9 @@ extends Resource
 # export (Array, Resource) var elites: = []
 
 export (bool) var enable_mods = true
-export (ModLoaderUtils.verbosity_level) var log_level: = ModLoaderUtils.verbosity_level.DEBUG
-export (String, DIR) var path_to_mods = "res://mods"
-export (String, DIR) var path_to_configs = "res://configs"
-export (bool) var steam_workshop_enabled = false
-export (String, DIR) var steam_workshop_path_override = ""
+export (ModLoaderUtils.VERBOSITY_LEVEL) var log_level: = ModLoaderUtils.VERBOSITY_LEVEL.DEBUG
 export (Array, String) var disabled_mods = []
+export (bool) var steam_workshop_enabled = false
+export (String, DIR) var override_path_to_mods = ""
+export (String, DIR) var override_path_to_configs = ""
+export (String, DIR) var override_path_to_workshop = ""

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -240,12 +240,12 @@ func _load_zips_in_folder(folder_path: String) -> int:
 		# "don't use ZIPs with unpacked mods!"
 		# https://github.com/godotengine/godot/issues/19815
 		# https://github.com/godotengine/godot/issues/16798
-		if OS.has_feature("editor") and not ModLoaderStore.ml_data.has_shown_editor_warning:
+		if OS.has_feature("editor") and not ModLoaderStore.ml_data.has_shown_editor_zips_warning:
 			ModLoaderUtils.log_warning(str(
 				"Loading any resource packs (.zip/.pck) with `load_resource_pack` will WIPE the entire virtual res:// directory. ",
 				"If you have any unpacked mods in ", UNPACKED_DIR, ", they will not be loaded. ",
 				"Please unpack your mod ZIPs instead, and add them to ", UNPACKED_DIR), LOG_NAME)
-			ModLoaderStore.ml_data.has_shown_editor_warning = true
+			ModLoaderStore.ml_data.has_shown_editor_zips_warning = true
 
 		ModLoaderUtils.log_debug("Found mod ZIP: %s" % mod_folder_global_path, LOG_NAME)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -240,12 +240,12 @@ func _load_zips_in_folder(folder_path: String) -> int:
 		# "don't use ZIPs with unpacked mods!"
 		# https://github.com/godotengine/godot/issues/19815
 		# https://github.com/godotengine/godot/issues/16798
-		if OS.has_feature("editor") and not ModLoaderStore.ml_data.has_shown_editor_zips_warning:
+		if OS.has_feature("editor") and not ModLoaderStore.has_shown_editor_zips_warning:
 			ModLoaderUtils.log_warning(str(
 				"Loading any resource packs (.zip/.pck) with `load_resource_pack` will WIPE the entire virtual res:// directory. ",
 				"If you have any unpacked mods in ", UNPACKED_DIR, ", they will not be loaded. ",
 				"Please unpack your mod ZIPs instead, and add them to ", UNPACKED_DIR), LOG_NAME)
-			ModLoaderStore.ml_data.has_shown_editor_zips_warning = true
+			ModLoaderStore.has_shown_editor_zips_warning = true
 
 		ModLoaderUtils.log_debug("Found mod ZIP: %s" % mod_folder_global_path, LOG_NAME)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -161,20 +161,6 @@ func _init() -> void:
 	is_initializing = false
 
 
-# Check the index position of the provided autoload (0 = 1st, 1 = 2nd, etc).
-# Returns a bool if the position does not match
-func _check_autoload_position(autoload_name: String, position_index: int, trigger_error: bool = false) -> bool:
-	var autoload_array = ModLoaderUtils.get_autoload_array()
-	var autoload_index = autoload_array.find(autoload_name) # mod_loader_index
-	var position_matches = autoload_index == position_index
-
-	if not position_matches and trigger_error:
-		var msg = "Expected %s to be the autoload in position %s, but this is currently %s" % [autoload_name, str(position_index), autoload_array[position_index]]
-		ModLoaderUtils.log_fatal(msg, LOG_NAME)
-
-	return position_matches
-
-
 # Check autoload positions:
 # Ensure 1st autoload is `ModLoaderStore`, and 2nd is `ModLoader`.
 func _check_autoload_positions() -> void:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -83,21 +83,21 @@ func _init() -> void:
 	if REQUIRE_CMD_LINE and not ModLoaderUtils.is_running_with_command_line_arg("--enable-mods"):
 		return
 
-	if not ModLoaderStore.ml_options.enable_mods:
-		ModLoaderUtils.log_info("Mods are currently disabled", LOG_NAME)
-		return
-
 	# Rotate the log files once on startup. Can't be checked in utils, since it's static
 	ModLoaderUtils.rotate_log_file()
-
-	# Log the autoloads order. Helpful when providing support to players
-	ModLoaderUtils.log_debug_json_print("Autoload order", ModLoaderUtils.get_autoload_array(), LOG_NAME)
 
 	# Ensure ModLoaderStore and ModLoader are the 1st and 2nd autoloads
 	_check_autoload_positions()
 
+	# Log the autoloads order. Helpful when providing support to players
+	ModLoaderUtils.log_debug_json_print("Autoload order", ModLoaderUtils.get_autoload_array(), LOG_NAME)
+
 	# Log game install dir
 	ModLoaderUtils.log_info("game_install_directory: %s" % ModLoaderUtils.get_local_folder_dir(), LOG_NAME)
+
+	if not ModLoaderStore.ml_options.enable_mods:
+		ModLoaderUtils.log_info("Mods are currently disabled", LOG_NAME)
+		return
 
 	# Loop over "res://mods" and add any mod zips to the unpacked virtual
 	# directory (UNPACKED_DIR)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -90,6 +90,9 @@ func _init() -> void:
 	# Rotate the log files once on startup. Can't be checked in utils, since it's static
 	ModLoaderUtils.rotate_log_file()
 
+	# Log the autoloads order. Helpful when providing support to players
+	ModLoaderUtils.log_debug_json_print("Autoload order", ModLoaderUtils.get_autoload_array(), LOG_NAME)
+
 	# Ensure ModLoaderStore and ModLoader are the 1st and 2nd autoloads
 	_check_autoload_positions()
 
@@ -164,22 +167,16 @@ func _init() -> void:
 # Check autoload positions:
 # Ensure 1st autoload is `ModLoaderStore`, and 2nd is `ModLoader`.
 func _check_autoload_positions() -> void:
-	# Log the autoloads order. Helpful when providing support to players
-	ModLoaderUtils.log_debug_json_print("Autoload order", ModLoaderUtils.get_autoload_array(), LOG_NAME)
-
-	var trigger_error := true
-	var override_cfg_path := ModLoaderUtils.get_override_path()
-	var is_override_cfg_setup :=  ModLoaderUtils.file_exists(override_cfg_path)
-
 	# If the override file exists we assume the ModLoader was setup with the --setup-create-override-cfg cli arg
 	# In that case the ModLoader will be the last entry in the autoload array
+	var override_cfg_path := ModLoaderUtils.get_override_path()
+	var is_override_cfg_setup :=  ModLoaderUtils.file_exists(override_cfg_path)
 	if is_override_cfg_setup:
-		trigger_error = false
 		ModLoaderUtils.log_info("override.cfg setup detected, ModLoader will be the last autoload loaded.", LOG_NAME)
 		return
 
-	var _pos_ml_store := ModLoaderGodot.check_autoload_position("ModLoaderStore", 0, trigger_error)
-	var _pos_ml_core := ModLoaderGodot.check_autoload_position("ModLoader", 1, trigger_error)
+	var _pos_ml_store := ModLoaderGodot.check_autoload_position("ModLoaderStore", 0, true)
+	var _pos_ml_core := ModLoaderGodot.check_autoload_position("ModLoader", 1, true)
 
 
 # Loop over "res://mods" and add any mod zips to the unpacked virtual directory

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -51,6 +51,11 @@ const new_global_classes := [
 		"language": "GDScript",
 		"path": "res://addons/mod_loader/api/deprecated.gd"
 	}, {
+		"base": "Object",
+		"class": "ModLoaderGodot",
+		"language": "GDScript",
+		"path": "res://addons/mod_loader/api/godot.gd"
+	}, {
 		"base": "Node",
 		"class": "ModLoaderSteam",
 		"language": "GDScript",
@@ -147,7 +152,10 @@ func reorder_autoloads() -> void:
 	for autoload in original_autoloads.keys():
 			ProjectSettings.set_setting(autoload, null)
 
-	# add ModLoader autoload (the * marks the path as autoload)
+	# Add ModLoaderStore autoload (the * marks the path as autoload)
+	ProjectSettings.set_setting("autoload/ModLoaderStore", "*" + "res://addons/mod_loader/mod_loader_store.gd")
+
+	# Add ModLoader autoload (the * marks the path as autoload)
 	ProjectSettings.set_setting("autoload/ModLoader", "*" + "res://addons/mod_loader/mod_loader.gd")
 
 	# add all previous autoloads back again

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -14,18 +14,13 @@ const LOG_NAME = "ModLoader:Store"
 # Vars
 # =============================================================================
 
-# Store for any internal data. Storing it here allows it to be accessed and used
-# by any file.
-# Usage: `ModLoaderStore.ml_data.KEY`
-var ml_data := {
-	# True if ModLoader has displayed the warning about using zipped mods
-	has_shown_editor_warning = false,
+# True if ModLoader has displayed the warning about using zipped mods
+var has_shown_editor_zips_warning := false
 
-	# Keeps track of logged messages, to avoid flooding the log with duplicate notices
-	# Can also be used by mods, eg. to create an in-game developer console that
-	# shows messages
-	logged_messages = [],
-}
+# Keeps track of logged messages, to avoid flooding the log with duplicate notices
+# Can also be used by mods, eg. to create an in-game developer console that
+# shows messages
+var logged_messages := []
 
 # These variables handle various options, which can be changed either via
 # Godot's GUI (with the options.tres resource file), or via CLI args.
@@ -91,7 +86,7 @@ func _update_ml_options_from_cli_args() -> void:
 	# Set via: --mods-path
 	# Example: --mods-path="C://path/mods"
 	var cmd_line_mod_path := ModLoaderUtils.get_cmd_line_arg_value("--mods-path")
-	if not cmd_line_mod_path == "":
+	if cmd_line_mod_path:
 		ml_options.override_path_to_mods = cmd_line_mod_path
 		ModLoaderUtils.log_info("The path mods are loaded from has been changed via the CLI arg `--mods-path`, to: " + cmd_line_mod_path, LOG_NAME)
 
@@ -99,7 +94,7 @@ func _update_ml_options_from_cli_args() -> void:
 	# Set via: --configs-path
 	# Example: --configs-path="C://path/configs"
 	var cmd_line_configs_path := ModLoaderUtils.get_cmd_line_arg_value("--configs-path")
-	if not cmd_line_configs_path == "":
+	if cmd_line_configs_path:
 		ml_options.override_path_to_configs = cmd_line_configs_path
 		ModLoaderUtils.log_info("The path configs are loaded from has been changed via the CLI arg `--configs-path`, to: " + cmd_line_configs_path, LOG_NAME)
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -1,0 +1,112 @@
+extends Node
+
+# ModLoaderStore
+# Singleton (autoload) for storing data. Should be added before ModLoader,
+# as an autoload called `ModLoaderStore`
+
+
+# Constants
+# =============================================================================
+
+const LOG_NAME = "ModLoader:Store"
+
+
+# Vars
+# =============================================================================
+
+# Store for any internal data. Storing it here allows it to be accessed and used
+# by any file.
+# Usage: `ModLoaderStore.ml_data.KEY`
+var ml_data := {
+	# True if ModLoader has displayed the warning about using zipped mods
+	has_shown_editor_warning = false,
+
+	# Keeps track of logged messages, to avoid flooding the log with duplicate notices
+	# Can also be used by mods, eg. to create an in-game developer console that
+	# shows messages
+	logged_messages = [],
+}
+
+# These variables handle various options, which can be changed either via
+# Godot's GUI (with the options.tres resource file), or via CLI args.
+# Usage: `ModLoaderStore.ml_options.KEY`
+# See: res://addons/mod_loader/options/options.tres
+# See: res://addons/mod_loader/classes/options_profile.gd
+var ml_options := {
+	enable_mods = true,
+	log_level = ModLoaderUtils.VERBOSITY_LEVEL.DEBUG,
+
+	# Array of disabled mods (contains mod IDs as strings)
+	disabled_mods = [],
+
+	# If true, ModLoader will load mod ZIPs from the Steam workshop directory,
+	# instead of the default location (res://mods)
+	steam_workshop_enabled = false,
+
+	# Overrides for the path mods/configs/workshop folders are loaded from.
+	# Only applied if custom settings are provided, either via the options.tres
+	# resource, or via CLI args. Note that CLI args can be tested in the editor
+	# via: Project Settings > Display> Editor > Main Run Args
+	override_path_to_mods = "",    # Default if unspecified: "res://mods"    -- get with ModLoaderUtils.get_path_to_mods()
+	override_path_to_configs = "", # Default if unspecified: "res://configs" -- get with ModLoaderUtils.get_path_to_configs()
+
+	# Can be used in the editor to load mods from your Steam workshop directory
+	override_path_to_workshop = "",
+}
+
+
+# Methods
+# =============================================================================
+
+func _init():
+	_update_ml_options_from_options_resource()
+	_update_ml_options_from_cli_args()
+
+
+# Update ModLoader's options, via the custom options resource
+func _update_ml_options_from_options_resource() -> void:
+	# Path to the options resource
+	# See: res://addons/mod_loader/classes/options_current.gd
+	var ml_options_path := "res://addons/mod_loader/options/options.tres"
+
+	# Get user options for ModLoader
+	if File.new().file_exists(ml_options_path):
+		var options_resource := load(ml_options_path)
+		if not options_resource.current_options == null:
+			var current_options: Resource = options_resource.current_options
+			# Update from the options in the resource
+			for key in ml_options:
+				ml_options[key] = current_options[key]
+	else:
+		ModLoaderUtils.log_fatal(str("A critical file is missing: ", ml_options_path), LOG_NAME)
+
+
+# Update ModLoader's options, via CLI args
+func _update_ml_options_from_cli_args() -> void:
+	# Disable mods
+	if ModLoaderUtils.is_running_with_command_line_arg("--disable-mods"):
+		ml_options.enable_mods = false
+
+	# Override paths to mods
+	# Set via: --mods-path
+	# Example: --mods-path="C://path/mods"
+	var cmd_line_mod_path := ModLoaderUtils.get_cmd_line_arg_value("--mods-path")
+	if not cmd_line_mod_path == "":
+		ml_options.override_path_to_mods = cmd_line_mod_path
+		ModLoaderUtils.log_info("The path mods are loaded from has been changed via the CLI arg `--mods-path`, to: " + cmd_line_mod_path, LOG_NAME)
+
+	# Override paths to configs
+	# Set via: --configs-path
+	# Example: --configs-path="C://path/configs"
+	var cmd_line_configs_path := ModLoaderUtils.get_cmd_line_arg_value("--configs-path")
+	if not cmd_line_configs_path == "":
+		ml_options.override_path_to_configs = cmd_line_configs_path
+		ModLoaderUtils.log_info("The path configs are loaded from has been changed via the CLI arg `--configs-path`, to: " + cmd_line_configs_path, LOG_NAME)
+
+	# Log level verbosity
+	if ModLoaderUtils.is_running_with_command_line_arg("-vvv") or ModLoaderUtils.is_running_with_command_line_arg("--log-debug"):
+		ml_options.log_level = ModLoaderUtils.VERBOSITY_LEVEL.DEBUG
+	elif ModLoaderUtils.is_running_with_command_line_arg("-vv") or ModLoaderUtils.is_running_with_command_line_arg("--log-info"):
+		ml_options.log_level = ModLoaderUtils.VERBOSITY_LEVEL.INFO
+	elif ModLoaderUtils.is_running_with_command_line_arg("-v") or ModLoaderUtils.is_running_with_command_line_arg("--log-warning"):
+		ml_options.log_level = ModLoaderUtils.VERBOSITY_LEVEL.WARNING

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -4,7 +4,7 @@ extends Node
 const LOG_NAME := "ModLoader:ModLoaderUtils"
 const MOD_LOG_PATH := "user://logs/modloader.log"
 
-enum verbosity_level {
+enum VERBOSITY_LEVEL {
 	ERROR,
 	WARNING,
 	INFO,
@@ -82,16 +82,16 @@ static func _loader_log(message: String, mod_name: String, log_type: String = "i
 			push_error(message)
 			_write_to_log_file(log_message)
 		"warning":
-			if _get_verbosity() >= verbosity_level.WARNING:
+			if _get_verbosity() >= VERBOSITY_LEVEL.WARNING:
 				print(prefix + message)
 				push_warning(message)
 				_write_to_log_file(log_message)
 		"info", "success":
-			if _get_verbosity() >= verbosity_level.INFO:
+			if _get_verbosity() >= VERBOSITY_LEVEL.INFO:
 				print(prefix + message)
 				_write_to_log_file(log_message)
 		"debug":
-			if _get_verbosity() >= verbosity_level.DEBUG:
+			if _get_verbosity() >= VERBOSITY_LEVEL.DEBUG:
 				print(prefix + message)
 				_write_to_log_file(log_message)
 
@@ -187,17 +187,7 @@ static func clear_old_log_backups() -> void:
 
 
 static func _get_verbosity() -> int:
-	if is_running_with_command_line_arg("-vvv") or is_running_with_command_line_arg("--log-debug"):
-		return verbosity_level.DEBUG
-	if is_running_with_command_line_arg("-vv") or is_running_with_command_line_arg("--log-info"):
-		return verbosity_level.INFO
-	if is_running_with_command_line_arg("-v") or is_running_with_command_line_arg("--log-warning"):
-		return verbosity_level.WARNING
-
-	if OS.has_feature("editor"):
-		return verbosity_level.DEBUG
-
-	return verbosity_level.ERROR
+	return ModLoaderStore.ml_options.log_level
 
 
 # Check if the provided command line argument was present when launching the game
@@ -532,3 +522,22 @@ static func save_string_to_file(save_string: String, filepath: String) -> bool:
 static func save_dictionary_to_json_file(data: Dictionary, filepath: String) -> bool:
 	var json_string = JSON.print(data, "\t")
 	return save_string_to_file(json_string, filepath)
+
+
+# Paths
+# =============================================================================
+
+# Get the path to the mods folder, with any applicable overrides applied
+static func get_path_to_mods() -> String:
+	var mods_folder_path := get_local_folder_dir("mods")
+	if ModLoaderStore.ml_options.override_path_to_mods:
+		mods_folder_path = ModLoaderStore.ml_options.override_path_to_mods
+	return mods_folder_path
+
+
+# Get the path to the configs folder, with any applicable overrides applied
+static func get_path_to_configs() -> String:
+	var configs_path := get_local_folder_dir("configs")
+	if ModLoaderStore.ml_options.override_path_to_configs:
+		configs_path = ModLoaderStore.ml_options.override_path_to_configs
+	return configs_path

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -187,7 +187,13 @@ static func clear_old_log_backups() -> void:
 
 
 static func _get_verbosity() -> int:
-	return ModLoaderStore.ml_options.log_level
+	if not ModLoaderStore:
+		# This lets us get a verbosity level even when ModLoaderStore is not in
+		# the correct autoload position (which they'll be notified about via
+		# `_check_autoload_positions`)
+		return VERBOSITY_LEVEL.DEBUG
+	else:
+		return ModLoaderStore.ml_options.log_level
 
 
 # Check if the provided command line argument was present when launching the game

--- a/addons/mod_loader/options/profiles/current.tres
+++ b/addons/mod_loader/options/profiles/current.tres
@@ -6,8 +6,8 @@
 script = ExtResource( 1 )
 enable_mods = true
 log_level = 3
-path_to_mods = "res://mods"
-path_to_configs = "res://configs"
-steam_workshop_enabled = false
-steam_workshop_path_override = ""
 disabled_mods = [  ]
+steam_workshop_enabled = false
+override_path_to_mods = ""
+override_path_to_configs = ""
+override_path_to_workshop = ""

--- a/addons/mod_loader/options/profiles/default.tres
+++ b/addons/mod_loader/options/profiles/default.tres
@@ -2,13 +2,12 @@
 
 [ext_resource path="res://addons/mod_loader/classes/options_profile.gd" type="Script" id=1]
 
-
 [resource]
 script = ExtResource( 1 )
 enable_mods = true
 log_level = 3
-path_to_mods = "res://mods"
-path_to_configs = "res://configs"
-steam_workshop_enabled = false
-steam_workshop_path_override = ""
 disabled_mods = [  ]
+steam_workshop_enabled = false
+override_path_to_mods = ""
+override_path_to_configs = ""
+override_path_to_workshop = ""

--- a/addons/mod_loader/options/profiles/disable_mods.tres
+++ b/addons/mod_loader/options/profiles/disable_mods.tres
@@ -2,13 +2,12 @@
 
 [ext_resource path="res://addons/mod_loader/classes/options_profile.gd" type="Script" id=1]
 
-
 [resource]
 script = ExtResource( 1 )
 enable_mods = false
 log_level = 3
-path_to_mods = "res://mods"
-path_to_configs = "res://configs"
-steam_workshop_enabled = false
-steam_workshop_path_override = ""
 disabled_mods = [  ]
+steam_workshop_enabled = false
+override_path_to_mods = ""
+override_path_to_configs = ""
+override_path_to_workshop = ""

--- a/addons/mod_loader/options/profiles/production_no_workshop.tres
+++ b/addons/mod_loader/options/profiles/production_no_workshop.tres
@@ -2,13 +2,12 @@
 
 [ext_resource path="res://addons/mod_loader/classes/options_profile.gd" type="Script" id=1]
 
-
 [resource]
 script = ExtResource( 1 )
 enable_mods = true
 log_level = 2
-path_to_mods = "res://mods"
-path_to_configs = "res://configs"
-steam_workshop_enabled = false
-steam_workshop_path_override = ""
 disabled_mods = [  ]
+steam_workshop_enabled = false
+override_path_to_mods = ""
+override_path_to_configs = ""
+override_path_to_workshop = ""

--- a/addons/mod_loader/options/profiles/production_workshop.tres
+++ b/addons/mod_loader/options/profiles/production_workshop.tres
@@ -2,13 +2,12 @@
 
 [ext_resource path="res://addons/mod_loader/classes/options_profile.gd" type="Script" id=1]
 
-
 [resource]
 script = ExtResource( 1 )
 enable_mods = true
 log_level = 2
-path_to_mods = "res://mods"
-path_to_configs = "res://configs"
-steam_workshop_enabled = true
-steam_workshop_path_override = ""
 disabled_mods = [  ]
+steam_workshop_enabled = true
+override_path_to_mods = ""
+override_path_to_configs = ""
+override_path_to_workshop = ""


### PR DESCRIPTION
Adds a new singleton called `ModLoaderStore`, which comes before `ModLoader` in the autoload order. This new singleton is a data store, and lets us reference data that was previously held as local vars in ModLoader, and which therefore may not have been accessible to all methods due to ModLoader not being initialised during its `_init()` phase.

I have implemented the following:

- Create the new ModLoaderStore singleton _(closes [#161](https://github.com/GodotModding/godot-mod-loader/pull/146))_.
- Moved some local variables from `ModLoader` to `ModLoaderStore` _(closes [#161](https://github.com/GodotModding/godot-mod-loader/pull/146))_.
- Implemented the path override options that were missing from the recent ML Options work _(follows [#145](https://github.com/GodotModding/godot-mod-loader/pull/145))_.
- Implemented the option to disable mods by mod ID strings _(via [#160](https://github.com/GodotModding/godot-mod-loader/pull/160))_.
- Options data can still be overridden by *options.tres*, but the stored data can also now be overridden by CLI args (with CLI args having priority).
    - This means we have one primary place to get/set data, and we don't need to keep checking CLI args (eg. for log verbosity levels, which previously checked the CLI args every time a log was used).
- New utility funcs to get critical paths have also been added, which apply the overrides, so you don't need to check for overrides every time you get the mods/configs/workshop paths:
    - `ModLoaderUtils.get_path_to_mods`
    - `ModLoaderUtils.get_path_to_configs`
    - `ModLoaderSteam.get_path_to_workshop` (renamed from `get_steam_workshop_dir` to match this new convention)
- Renamed path override options in *options.tres* to `override_path_to_*` for consistency
- Updated the setup process to include `ModLoaderStore`
- Updated the autoload order check, and added a new utility method called `check_autoload_position` to a new class called `ModLoaderGodot`

**Notes:**

- `ModLoader` still has lots of other local vars that we may want to move to `ModLoaderStore`. We may also want to provide utility funcs to retrieve this data, eg. `is_mod_active(mod_id: String)`, but all this can be handled in subsequent PRs.

**Closes:**

- #146
- #161
- #151

**Works towards:**

- #109
- #140 
- #141

**Finishes:**

- #145
- #157 _(addresses the issue mentioned [here](https://github.com/GodotModding/godot-mod-loader/pull/157#issuecomment-1451331286))_

### Subsequent Work

As raised in the review comments, there are a few things that we can do following this PR:

- The things noted in the "works towards" section above can be addressed (eg [via](https://github.com/GodotModding/godot-mod-loader/pull/172#discussion_r1127866573))
- _mod_loader_setup.gd_ - The new autoload check can be used here ([via](https://github.com/GodotModding/godot-mod-loader/pull/172#discussion_r1127911682))
- `REQUIRE_CMD_LINE` - This could be a configurable option ([via](https://github.com/GodotModding/godot-mod-loader/pull/172#discussion_r1127747473))