### PR TITLE
style: :art: Add `\t` indent to `JSON.print()`

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -141,7 +141,7 @@ func to_json() -> String:
 				"image": image,
 			}
 		}
-	})
+	}, "\t")
 
 
 # Handles deprecation of the single string value in the compatible_mod_loader_version.


### PR DESCRIPTION
This will make the generated JSON a lot more readable if it is saved to a file.