### PR TITLE
feat: :sparkles: added load_before

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -27,6 +27,7 @@ var compatible_game_version: PoolStringArray = []
 var compatible_mod_loader_version: PoolStringArray = []
 # only used for information
 var incompatibilities: PoolStringArray = []
+var load_before: PoolStringArray = []
 var tags : PoolStringArray = []
 var config_defaults := {}
 var description_rich := ""
@@ -77,6 +78,7 @@ func _init(manifest: Dictionary) -> void:
 	var godot_details: Dictionary = manifest.extra.godot
 	authors = ModLoaderUtils.get_array_from_dict(godot_details, "authors")
 	incompatibilities = ModLoaderUtils.get_array_from_dict(godot_details, "incompatibilities")
+	load_before = ModLoaderUtils.get_array_from_dict(godot_details, "load_before")
 	compatible_game_version = ModLoaderUtils.get_array_from_dict(godot_details, "compatible_game_version")
 	compatible_mod_loader_version = _handle_compatible_mod_loader_version(godot_details)
 	description_rich = ModLoaderUtils.get_string_from_dict(godot_details, "description_rich")
@@ -113,6 +115,7 @@ func get_as_dict() -> Dictionary:
 		"compatible_game_version": compatible_game_version,
 		"compatible_mod_loader_version": compatible_mod_loader_version,
 		"incompatibilities": incompatibilities,
+		"load_before": load_before,
 		"tags": tags,
 		"config_defaults": config_defaults,
 		"description_rich": description_rich,
@@ -135,6 +138,7 @@ func to_json() -> String:
 				"compatible_game_version": compatible_game_version,
 				"compatible_mod_loader_version": compatible_mod_loader_version,
 				"incompatibilities": incompatibilities,
+				"load_before": load_before,
 				"tags": tags,
 				"config_defaults": config_defaults,
 				"description_rich": description_rich,

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -493,13 +493,24 @@ func _check_load_before(mod: ModData) -> void:
 	if mod.manifest.load_before.size() == 0:
 		return
 
-	# Add the mod to the dependency arrays
+	# For each mod id in load_before
 	for load_before_id in mod.manifest.load_before:
 		var load_before_mod_dependencies = mod_data[load_before_id].manifest.dependencies
+		# Check if it's already a dependency
+		if mod.dir_name in load_before_mod_dependencies:
+			ModLoaderUtils.log_debug(
+				"Load before detected -> Skipping %s because it's already a dependency for %s"
+				% [mod.dir_name, load_before_id], LOG_NAME
+			)
+			return
+		# Add the mod to the dependency array
 		load_before_mod_dependencies.append(mod.dir_name)
 		mod_data[load_before_id].manifest.dependencies = load_before_mod_dependencies
 
-	ModLoaderUtils.log_debug("Load before detected -> Added %s as dependency for %s" % [mod.dir_name, mod.manifest.load_before], LOG_NAME)
+	ModLoaderUtils.log_debug(
+		"Load before detected -> Added %s as dependency for %s"
+		% [mod.dir_name, mod.manifest.load_before], LOG_NAME
+	)
 
 
 # Get the load order of mods, using a custom sorter

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -146,9 +146,9 @@ func _init() -> void:
 		var mod: ModData = mod_data[dir_name]
 		if not mod.is_loadable:
 			continue
-			var is_circular := _check_dependencies(mod)
-			if is_circular:
-				return
+		var is_circular := _check_dependencies(mod)
+		if is_circular:
+			return
 
 	# Sort mod_load_order by the importance score of the mod
 	mod_load_order = _get_load_order(mod_data.values())


### PR DESCRIPTION
The code from 
- #115 

## *Original Description*

Adds functionality to specify a mod you want to load before your own mod. 

Load before field added to  *manifest.json* in *extra* -> *godot* -> *load_before*

For example:
`"load_before": ["Darkly77-ContentLoader"],`

```JSON
{
	"name": "WhatAmILookingAt",
	"namespace": "KANA",
	"version_number": "1.0.0",
	"description": "Tells you where this thing is from.",
	"website_url": "https://github.com/BrotatoMods",
	"dependencies": [],
	"extra": {
		"godot": {
			"incompatibilities": [],
			"load_before": ["Darkly77-ContentLoader"],
			"authors": ["KANA"],
			"compatible_mod_loader_version": "4.3.0",
			"compatible_game_version": ["0.8.0.3"],
			"config_defaults": {}
		}
	}
}
```

Will need some more testing, this is just a naive implementation.

---
closes #114 

---

## I tested it a bit more

- Mods added to `load_before` should not be added to `dependencies` this cancels out the effect.
Because a cyclic reference is created and the dependency check will break out of the loop, so both mods end up with the same importance score.
- It worked successfully for this simple test case
   - Mod 1 no dependencies
   - Mod 2 `load_before` Mod 1
   - Mod 3 `dependency` on Mod 1