### PR TITLE
refactor: :recycle: `validate_distinct_mod_ids_in_arrays()`

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -266,6 +266,7 @@ static func validate_distinct_mod_ids_in_arrays(
 	array_one: PoolStringArray,
 	array_two: PoolStringArray,
 	array_description: PoolStringArray,
+	additional_info := "",
 	is_silent := false
 ) -> bool:
 	# Initialize an empty array to hold any overlaps.
@@ -281,8 +282,8 @@ static func validate_distinct_mod_ids_in_arrays(
 		if not is_silent:
 			ModLoaderUtils.log_fatal(
 				(
-					"The mod -> %s lists the same mod(s) -> %s - in %s and %s"
-					% [mod_id, overlaps, array_description[0], array_description[1]]
+					"The mod -> %s lists the same mod(s) -> %s - in \"%s\" and \"%s\". %s"
+					% [mod_id, overlaps, array_description[0], array_description[1], additional_info]
 				),
 				LOG_NAME
 			)

--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -277,20 +277,20 @@ static func validate_distinct_mod_ids_in_arrays(
 		if array_two.has(mod_id):
 			overlaps.push_back(mod_id)
 
-	# If any overlaps were found, log a fatal error message and return true.
-	if overlaps.size() > 0:
-		if not is_silent:
-			ModLoaderUtils.log_fatal(
-				(
-					"The mod -> %s lists the same mod(s) -> %s - in \"%s\" and \"%s\". %s"
-					% [mod_id, overlaps, array_description[0], array_description[1], additional_info]
-				),
-				LOG_NAME
-			)
-		return false
+	# If no overlaps were found
+	if overlaps.size() == 0:
+		return true
 
-	# If no overlaps were found, return false.
-	return true
+	# If any overlaps were found
+	if not is_silent:
+		ModLoaderUtils.log_fatal(
+			(
+				"The mod -> %s lists the same mod(s) -> %s - in \"%s\" and \"%s\". %s"
+				% [mod_id, overlaps, array_description[0], array_description[1], additional_info]
+			),
+			LOG_NAME
+		)
+		return false
 
 
 static func is_mod_id_array_valid(own_mod_id: String, mod_id_array: PoolStringArray, mod_id_array_description: String, is_silent := false) -> bool:

--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -286,10 +286,10 @@ static func validate_distinct_mod_ids_in_arrays(
 				),
 				LOG_NAME
 			)
-		return true
+		return false
 
 	# If no overlaps were found, return false.
-	return false
+	return true
 
 
 static func is_mod_id_array_valid(own_mod_id: String, mod_id_array: PoolStringArray, mod_id_array_description: String, is_silent := false) -> bool:

--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -292,6 +292,9 @@ static func validate_distinct_mod_ids_in_arrays(
 		)
 		return false
 
+	# If silent just return false
+	return false
+
 
 static func is_mod_id_array_valid(own_mod_id: String, mod_id_array: PoolStringArray, mod_id_array_description: String, is_silent := false) -> bool:
 	var is_valid := true

--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -91,7 +91,19 @@ func _init(manifest: Dictionary) -> void:
 	var mod_id = get_mod_id()
 	if (not is_mod_id_array_valid(mod_id, dependencies, "dependency") or
 		not is_mod_id_array_valid(mod_id, incompatibilities, "incompatibility") or
-		not is_mod_id_array_valid(mod_id, optional_dependencies, "optional_dependency")):
+		not is_mod_id_array_valid(mod_id, optional_dependencies, "optional_dependency") or
+		not validate_distinct_mod_ids_in_arrays(
+			mod_id,
+			dependencies,
+			incompatibilities,
+			["dependencies", "incompatibilities"]
+		) or
+		not validate_distinct_mod_ids_in_arrays(
+			mod_id,
+			optional_dependencies,
+			incompatibilities,
+			["optional_dependencies", "incompatibilities"]
+		)):
 		return
 
 
@@ -249,28 +261,28 @@ static func is_semver_valid(check_version_number: String, is_silent := false) ->
 	return true
 
 
-# Validates a mod's dependencies and incompatibilities to ensure they don't conflict.
-static func validate_dependencies_and_incompatibilities_conflicts(
+static func validate_distinct_mod_ids_in_arrays(
 	mod_id: String,
-	dependencies: PoolStringArray,
-	incompatibilities: PoolStringArray,
+	array_one: PoolStringArray,
+	array_two: PoolStringArray,
+	array_description: PoolStringArray,
 	is_silent := false
 ) -> bool:
 	# Initialize an empty array to hold any overlaps.
 	var overlaps: PoolStringArray = []
 
 	# Loop through each incompatibility and check if it is also listed as a dependency.
-	for incompatibility in incompatibilities:
-		if dependencies.has(incompatibility):
-			overlaps.push_back(incompatibility)
+	for mod_id in array_one:
+		if array_two.has(mod_id):
+			overlaps.push_back(mod_id)
 
 	# If any overlaps were found, log a fatal error message and return true.
 	if overlaps.size() > 0:
 		if not is_silent:
 			ModLoaderUtils.log_fatal(
 				(
-					"The mod -> %s lists the same mod(s) -> %s - in incompatibilities and dependencies"
-					% [mod_id, overlaps]
+					"The mod -> %s lists the same mod(s) -> %s - in %s and %s"
+					% [mod_id, overlaps, array_description[0], array_description[1]]
 				),
 				LOG_NAME
 			)


### PR DESCRIPTION
- reworked `validate_dependencies_and_incompatibilities_conflicts()` to work with any arrays
-  renamed it to `validate_distinct_mod_ids_in_arrays()`. 
- Fixed the accidentally removed function call of `validate_dependencies_and_incompatibilities_conflicts()` in `_init()`
- Added validation to check for distinct mod_ids in `incompatibilities` and `optional_dependencies`.

closes #192