### PR TITLE
refactor: :recycle: Check for valid mod ids in `load_before`

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -99,7 +99,8 @@ func _init(manifest: Dictionary) -> void:
 	if (
 		not is_mod_id_array_valid(mod_id, dependencies, "dependency") or
 		not is_mod_id_array_valid(mod_id, incompatibilities, "incompatibility") or
-		not is_mod_id_array_valid(mod_id, optional_dependencies, "optional_dependency")
+		not is_mod_id_array_valid(mod_id, optional_dependencies, "optional_dependency") or
+		not is_mod_id_array_valid(mod_id, load_before, "load_before")
 	):
 		return
 


### PR DESCRIPTION
Adds a `is_mod_id_array_valid()` func call for `load_before` to the `_init()` func.

*closes #186*