### PR TITLE
feat: added _remove_extension

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -721,7 +721,8 @@ func _apply_extension(extension_path)->Script:
 	return child_script
 
 
-func _reset_extension(parent_script_path)->Script:
+# Used to fully reset the provided script to a state prior of any extension
+func _reset_extension(parent_script_path: String)->Script:
 	# Check path to file exists
 	if not File.new().file_exists(parent_script_path):
 		ModLoaderUtils.log_error("The parent script path '%s' does not exist" % [parent_script_path], LOG_NAME)
@@ -732,13 +733,17 @@ func _reset_extension(parent_script_path)->Script:
 		ModLoaderUtils.log_error("The parent script path '%s' has not been extended" % [parent_script_path], LOG_NAME)
 		return null
 
-	# Check if the script to reset has been extended
+	# Check if the script to reset has anything actually saved
+	# If we ever encounter this it means something went very wrong in extending
 	if not _saved_scripts[parent_script_path].size() > 0:
 		ModLoaderUtils.log_error("The parent script path '%s' does not have the base script saved, this should never happen, if you encounter this please create an issue in the github repository" % [parent_script_path], LOG_NAME)
 		return null
 
 	var parent_script = _saved_scripts[parent_script_path][0]
 	parent_script.take_over_path(parent_script_path)
+
+	# Remove the script after it has been reset so we do not do it again
+	_saved_scripts.erase(parent_script_path)
 
 	return parent_script
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -821,7 +821,9 @@ func install_script_extension(child_script_path:String):
 
 func uninstall_script_extension(extension_script_path: String):
 
-	pass
+	# Currently this is the only thing we do, but it is better to expose
+	# this function like this for further changes
+	_remove_extension(extension_script_path)
 
 
 # Register an array of classes to the global scope, since Godot only does that in the editor.

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -715,7 +715,8 @@ func _apply_extension(extension_path)->Script:
 	# All the scripts are saved in order already
 	if not _saved_scripts.has(parent_script_path):
 		_saved_scripts[parent_script_path] = []
-		# The first entry in the script path array will be the copy of the base script
+		# The first entry in the saved script array that has the path
+		# used as a key will be the duplicate of the not modified script
 		_saved_scripts[parent_script_path].append(parent_script.duplicate())
 	_saved_scripts[parent_script_path].append(child_script)
 
@@ -729,7 +730,7 @@ func _apply_extension(extension_path)->Script:
 func _remove_extension(extension_path: String):
 	# Check path to file exists
 	if not File.new().file_exists(extension_path):
-		ModLoaderUtils.log_error("The extension script path '%s' does not exist" % [extension_path], LOG_NAME)
+		ModLoaderUtils.log_error("The extension script path \"%s\" does not exist" % [extension_path], LOG_NAME)
 		return null
 
 	var extension_script: Script = ResourceLoader.load(extension_path)
@@ -738,28 +739,27 @@ func _remove_extension(extension_path: String):
 
 	# Check if the script to reset has been extended
 	if not _saved_scripts.has(parent_script_path):
-		ModLoaderUtils.log_error("The extension parent script path '%s' has not been extended" % [parent_script_path], LOG_NAME)
+		ModLoaderUtils.log_error("The extension parent script path \"%s\" has not been extended" % [parent_script_path], LOG_NAME)
 		return
 
 	# Check if the script to reset has anything actually saved
 	# If we ever encounter this it means something went very wrong in extending
 	if not _saved_scripts[parent_script_path].size() > 0:
-		ModLoaderUtils.log_error("The extension script path '%s' does not have the base script saved, this should never happen, if you encounter this please create an issue in the github repository" % [parent_script_path], LOG_NAME)
+		ModLoaderUtils.log_error("The extension script path \"%s\" does not have the base script saved, this should never happen, if you encounter this please create an issue in the github repository" % [parent_script_path], LOG_NAME)
 		return
 
-	var parent_script_extensions = _saved_scripts[parent_script_path].duplicate()
+	var parent_script_extensions: Array = _saved_scripts[parent_script_path].duplicate()
 	parent_script_extensions.remove(0)
 
 	# Searching for the extension that we want to remove
-	var found_script_extension = null
+	var found_script_extension: Script = null
 	for script_extension in parent_script_extensions:
 		if script_extension.get_meta("extension_script_path") == extension_path:
-			ModLoaderUtils.log_debug("Extension Check %s Extension Passed %s" %[script_extension.get_meta("extension_script_path"), extension_path], LOG_NAME)
 			found_script_extension = script_extension
 			break
 
 	if found_script_extension == null:
-		ModLoaderUtils.log_error("The extension script path '%s' has not been found in the saved extension of the base script" % [parent_script_path], LOG_NAME)
+		ModLoaderUtils.log_error("The extension script path \"%s\" has not been found in the saved extension of the base script" % [parent_script_path], LOG_NAME)
 		return
 	parent_script_extensions.erase(found_script_extension)
 
@@ -774,22 +774,22 @@ func _remove_extension(extension_path: String):
 # Used to fully reset the provided script to a state prior of any extension
 func _reset_extension(parent_script_path: String):
 	# Check path to file exists
-	if not File.new().file_exists(parent_script_path):
-		ModLoaderUtils.log_error("The parent script path '%s' does not exist" % [parent_script_path], LOG_NAME)
+	if not ModLoaderUtils.file_exists(parent_script_path):
+		ModLoaderUtils.log_error("The parent script path \"%s\" does not exist" % [parent_script_path], LOG_NAME)
 		return
 
 	# Check if the script to reset has been extended
 	if not _saved_scripts.has(parent_script_path):
-		ModLoaderUtils.log_error("The parent script path '%s' has not been extended" % [parent_script_path], LOG_NAME)
+		ModLoaderUtils.log_error("The parent script path \"%s\" has not been extended" % [parent_script_path], LOG_NAME)
 		return
 
 	# Check if the script to reset has anything actually saved
 	# If we ever encounter this it means something went very wrong in extending
 	if not _saved_scripts[parent_script_path].size() > 0:
-		ModLoaderUtils.log_error("The parent script path '%s' does not have the base script saved, this should never happen, if you encounter this please create an issue in the github repository" % [parent_script_path], LOG_NAME)
+		ModLoaderUtils.log_error("The parent script path \"%s\" does not have the base script saved, \nthis should never happen, if you encounter this please create an issue in the github repository" % [parent_script_path], LOG_NAME)
 		return
 
-	var parent_script = _saved_scripts[parent_script_path][0]
+	var parent_script: Script = _saved_scripts[parent_script_path][0]
 	parent_script.take_over_path(parent_script_path)
 
 	# Remove the script after it has been reset so we do not do it again

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -693,6 +693,10 @@ func _apply_extension(extension_path)->Script:
 		return null
 
 	var child_script:Script = ResourceLoader.load(extension_path)
+	# Adding metadata that contains the extension script path
+	# We cannot get that path in any other way
+	# Passing the child_script as is would return the base script path
+	# Passing the .duplicate() would return a '' path
 	child_script.set_meta("extension_script_path", extension_path)
 
 	# Force Godot to compile the script now.
@@ -721,6 +725,7 @@ func _apply_extension(extension_path)->Script:
 	return child_script
 
 
+# Used to remove a specific extension
 func _remove_extension(extension_path: String):
 	# Check path to file exists
 	if not File.new().file_exists(extension_path):
@@ -745,6 +750,7 @@ func _remove_extension(extension_path: String):
 	var parent_script_extensions = _saved_scripts[parent_script_path].duplicate()
 	parent_script_extensions.remove(0)
 
+	# Searching for the extension that we want to remove
 	var found_script_extension = null
 	for script_extension in parent_script_extensions:
 		if script_extension.get_meta("extension_script_path") == extension_path:
@@ -757,8 +763,10 @@ func _remove_extension(extension_path: String):
 		return
 	parent_script_extensions.erase(found_script_extension)
 
+	# Preparing the script to have all other extensions reapllied
 	_reset_extension(parent_script_path)
 
+	# Reapplying all the extensions without the removed one
 	for script_extension in parent_script_extensions:
 		_apply_extension(script_extension.get_meta("extension_script_path"))
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -714,7 +714,6 @@ func _apply_extension(extension_path)->Script:
 		# The first entry in the script path array will be the copy of the base script
 		_saved_scripts[parent_script_path].append(parent_script.duplicate())
 	_saved_scripts[parent_script_path].append(child_script)
-	ModLoaderUtils.log_error("base script: %s" % str(_saved_scripts[parent_script_path]), LOG_NAME)
 
 	ModLoaderUtils.log_info("Installing script extension: %s <- %s" % [parent_script_path, extension_path], LOG_NAME)
 	child_script.take_over_path(parent_script_path)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -727,9 +727,9 @@ func _apply_extension(extension_path)->Script:
 
 
 # Used to remove a specific extension
-func _remove_extension(extension_path: String):
+func _remove_extension(extension_path: String) -> void:
 	# Check path to file exists
-	if not File.new().file_exists(extension_path):
+	if not ModLoaderUtils.file_exists(extension_path):
 		ModLoaderUtils.log_error("The extension script path \"%s\" does not exist" % [extension_path], LOG_NAME)
 		return null
 
@@ -772,7 +772,7 @@ func _remove_extension(extension_path: String):
 
 
 # Used to fully reset the provided script to a state prior of any extension
-func _reset_extension(parent_script_path: String):
+func _reset_extension(parent_script_path: String) -> void:
 	# Check path to file exists
 	if not ModLoaderUtils.file_exists(parent_script_path):
 		ModLoaderUtils.log_error("The parent script path \"%s\" does not exist" % [parent_script_path], LOG_NAME)
@@ -819,7 +819,7 @@ func install_script_extension(child_script_path:String):
 		_apply_extension(child_script_path)
 
 
-func uninstall_script_extension(extension_script_path: String):
+func uninstall_script_extension(extension_script_path: String) -> void:
 
 	# Currently this is the only thing we do, but it is better to expose
 	# this function like this for further changes


### PR DESCRIPTION
Requires: https://github.com/GodotModding/godot-mod-loader/pull/195
Adds `_remove_extension` that allows for removal of a specific extension, this resets the base script and then reinstalls all the other extensions in the already sorted order