### PR TITLE
fix: :bug: self setup chicken and egg problem

### DIFF
--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -77,17 +77,17 @@ func _init() -> void:
 	modloaderutils.log_debug("ModLoader setup initialized", LOG_NAME)
 
 	var mod_loader_index: int = modloaderutils.get_autoload_index("ModLoader")
+	var mod_loader_store_index: int = modloaderutils.get_autoload_index("ModLoaderStore")
 
 	# Avoid doubling the setup work
-	# Checks if the ModLoader Node is in the root of the scene tree
-	# and if the IS_LOADER_SETUP_APPLIED project setting is there
-	if mod_loader_index == 0:
+	# Checks if the ModLoaderStore is the first autoload and ModLoader the second
+	if mod_loader_store_index == 0 and mod_loader_index == 1:
 		modded_start()
 		return
 
 	# Check if --setup-create-override-cfg is passed,
-	# in that case the ModLoader just has to be somewhere in the autoloads.
-	if is_setup_create_override_cfg and mod_loader_index != -1:
+	# in that case the ModLoader and ModLoaderStore just have to be somewhere in the autoloads.
+	if is_setup_create_override_cfg and mod_loader_index != -1 and mod_loader_store_index != -1:
 		modded_start()
 		return
 

--- a/addons/mod_loader/mod_loader_utils.gd
+++ b/addons/mod_loader/mod_loader_utils.gd
@@ -190,13 +190,22 @@ static func clear_old_log_backups() -> void:
 
 
 static func _get_verbosity() -> int:
-	if not ModLoaderStore:
+	var modloader_store := get_modloader_store()
+	if not modloader_store:
 		# This lets us get a verbosity level even when ModLoaderStore is not in
 		# the correct autoload position (which they'll be notified about via
 		# `_check_autoload_positions`)
 		return VERBOSITY_LEVEL.DEBUG
 	else:
-		return ModLoaderStore.ml_options.log_level
+		return modloader_store.ml_options.log_level
+
+
+# Returns a reference to the ModLoaderStore autoload if it exists, or null otherwise.
+# This function can be used to get a reference to the ModLoaderStore autoload in functions
+# that may be called before the autoload is initialized.
+# If the ModLoaderStore autoload does not exist in the global scope, this function returns null.
+static func get_modloader_store() -> Object:
+	return Engine.get_singleton("ModLoaderStore") if Engine.has_singleton("ModLoaderStore") else null
 
 
 # Check if the provided command line argument was present when launching the game
@@ -576,15 +585,19 @@ static func save_dictionary_to_json_file(data: Dictionary, filepath: String) -> 
 
 # Get the path to the mods folder, with any applicable overrides applied
 static func get_path_to_mods() -> String:
+	var modloader_store := get_modloader_store()
 	var mods_folder_path := get_local_folder_dir("mods")
-	if ModLoaderStore.ml_options.override_path_to_mods:
-		mods_folder_path = ModLoaderStore.ml_options.override_path_to_mods
+	if modloader_store:
+		if modloader_store.ml_options.override_path_to_mods:
+			mods_folder_path = modloader_store.ml_options.override_path_to_mods
 	return mods_folder_path
 
 
 # Get the path to the configs folder, with any applicable overrides applied
 static func get_path_to_configs() -> String:
+	var modloader_store := get_modloader_store()
 	var configs_path := MOD_CONFIG_DIR_PATH
-	if ModLoaderStore.ml_options.override_path_to_configs:
-		configs_path = ModLoaderStore.ml_options.override_path_to_configs
+	if modloader_store:
+		if modloader_store.ml_options.override_path_to_configs:
+			configs_path = modloader_store.ml_options.override_path_to_configs
 	return configs_path


### PR DESCRIPTION
In #172 the ModLoaderUtils utility functions were updated to use the ModLoaderStore singleton. 
However, this caused an issue with the self-setup script, as the setup was getting stuck in an infinite loop due to the `ModLoaderStore` not being initialized yet. 
To resolve this issue, `get_modloader_store()` was added to *mod_loader_utils.gd*, which returns a reference to the `ModLoaderStore` singleton if it exists or `null` otherwise.

This functions use it now:
- `_get_verbosity()`
-  `get_path_to_mods()`
-  `get_path_to_configs()` 

Additionally, the `autoload index` check in the `_init()` function of *mod_loader_setup.gd* was updated to check for the right indexes of `ModLoader` and `ModLoaderStore`.

Tested with and without `--setup-create-override-cfg` .


closes #200