### PR TITLE
Fix mod id validation

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -370,7 +370,7 @@ static func is_mod_id_valid(original_mod_id: String, check_mod_id: String, type 
 	var check_namespace = split[0]
 	var check_name = split[1]
 	var re := RegEx.new()
-	re.compile("^[a-zA-Z0-9_]*$") # alphanumeric and _
+	re.compile("^[a-zA-Z0-9_]{3,}$") # alphanumeric and _ and at least 3 characters
 
 	if re.search(check_namespace) == null:
 		if not is_silent:


### PR DESCRIPTION
really simple check for length 3
@ithinkandicode do we really need all of that `type` stuff at the beginning of the method? what was the intended use for that and will that be followed up upon?