### PR TITLE
feat: mod reloading

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -191,6 +191,21 @@ func _load_mods() -> void:
 	ModLoaderUtils.log_success("DONE: Installed all script extensions", LOG_NAME)
 
 
+# Internal call to reload mods
+func _reload_mods() -> void:
+	_reset_mods()
+	_load_mods()
+
+
+# Internal call that handles the resetting of all mod related data
+func _reset_mods() -> void:
+	mod_data.clear()
+	mod_load_order.clear()
+	mod_missing_dependencies.clear()
+	script_extensions.clear()
+	_clear_extensions()
+
+
 # Check autoload positions:
 # Ensure 1st autoload is `ModLoaderStore`, and 2nd is `ModLoader`.
 func _check_autoload_positions() -> void:
@@ -830,11 +845,25 @@ func install_script_extension(child_script_path:String):
 		_apply_extension(child_script_path)
 
 
+# Remove a specific script from the vanilla extension chain
+# This will remove only the specifically provided extension
+# and keep all other extensions of that vanilla script running
 func uninstall_script_extension(extension_script_path: String) -> void:
 
 	# Currently this is the only thing we do, but it is better to expose
 	# this function like this for further changes
 	_remove_specific_extension(extension_script_path)
+
+
+# This function should be called only when actually necessary
+# as it can break the game and require a restart for mods
+# that do not fully use the mod loader systems
+# Used to reload already present mods and load new ones
+func reload_mods() -> void:
+
+	# Currently this is the only thing we do, but it is better to expose
+	# this function like this for further changes
+	_reload_mods()
 
 
 # Register an array of classes to the global scope, since Godot only does that in the editor.

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -203,7 +203,7 @@ func _reset_mods() -> void:
 	mod_load_order.clear()
 	mod_missing_dependencies.clear()
 	script_extensions.clear()
-	_clear_extensions()
+	_remove_all_extensions_from_all_scripts()
 
 
 # Check autoload positions:
@@ -746,7 +746,7 @@ func _apply_extension(extension_path)->Script:
 
 
 # Used to remove a specific extension
-func _remove_specific_extension(extension_path: String) -> void:
+func _remove_specific_extension_from_script(extension_path: String) -> void:
 	# Check path to file exists
 	if not ModLoaderUtils.file_exists(extension_path):
 		ModLoaderUtils.log_error("The extension script path \"%s\" does not exist" % [extension_path], LOG_NAME)
@@ -783,7 +783,7 @@ func _remove_specific_extension(extension_path: String) -> void:
 	parent_script_extensions.erase(found_script_extension)
 
 	# Preparing the script to have all other extensions reapllied
-	_remove_all_extensions(parent_script_path)
+	_remove_all_extensions_from_script(parent_script_path)
 
 	# Reapplying all the extensions without the removed one
 	for script_extension in parent_script_extensions:
@@ -791,7 +791,7 @@ func _remove_specific_extension(extension_path: String) -> void:
 
 
 # Used to fully reset the provided script to a state prior of any extension
-func _remove_all_extensions(parent_script_path: String) -> void:
+func _remove_all_extensions_from_script(parent_script_path: String) -> void:
 	# Check path to file exists
 	if not ModLoaderUtils.file_exists(parent_script_path):
 		ModLoaderUtils.log_error("The parent script path \"%s\" does not exist" % [parent_script_path], LOG_NAME)
@@ -815,10 +815,10 @@ func _remove_all_extensions(parent_script_path: String) -> void:
 	_saved_scripts.erase(parent_script_path)
 
 
-func _clear_extensions() -> void:
+func _remove_all_extensions_from_all_scripts() -> void:
 	var _to_remove_scripts = _saved_scripts.duplicate()
 	for script in _to_remove_scripts:
-		_remove_all_extensions(script)
+		_remove_all_extensions_from_script(script)
 
 
 # Helpers
@@ -851,12 +851,16 @@ func uninstall_script_extension(extension_script_path: String) -> void:
 
 	# Currently this is the only thing we do, but it is better to expose
 	# this function like this for further changes
-	_remove_specific_extension(extension_script_path)
+	_remove_specific_extension_from_script(extension_script_path)
 
 
 # This function should be called only when actually necessary
 # as it can break the game and require a restart for mods
-# that do not fully use the mod loader systems
+# that do not fully use the systems put in place by the mod loader,
+# so anything that just uses add_node, move_node ecc...
+# To not have your mod break on reload please use provided functions
+# like ModLoader::save_scene, ModLoader::append_node_in_scene and
+# all the functions that will be added in the next versions
 # Used to reload already present mods and load new ones
 func reload_mods() -> void:
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -101,6 +101,12 @@ func _init() -> void:
 		ModLoaderUtils.log_info("Mods are currently disabled", LOG_NAME)
 		return
 
+	_load_mods()
+
+	is_initializing = false
+
+
+func _load_mods() -> void:
 	# Loop over "res://mods" and add any mod zips to the unpacked virtual
 	# directory (UNPACKED_DIR)
 	var unzipped_mods := _load_mod_zips()
@@ -183,8 +189,6 @@ func _init() -> void:
 	_handle_script_extensions()
 
 	ModLoaderUtils.log_success("DONE: Installed all script extensions", LOG_NAME)
-
-	is_initializing = false
 
 
 # Check autoload positions:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -819,7 +819,6 @@ func _clear_extensions() -> void:
 	var _to_remove_scripts = _saved_scripts.duplicate()
 	for script in _to_remove_scripts:
 		_remove_all_extensions(script)
-	print(_saved_scripts)
 
 
 # Helpers

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -727,11 +727,11 @@ func _apply_extension(extension_path)->Script:
 
 
 # Used to remove a specific extension
-func _remove_extension(extension_path: String) -> void:
+func _remove_specific_extension(extension_path: String) -> void:
 	# Check path to file exists
 	if not ModLoaderUtils.file_exists(extension_path):
 		ModLoaderUtils.log_error("The extension script path \"%s\" does not exist" % [extension_path], LOG_NAME)
-		return null
+		return
 
 	var extension_script: Script = ResourceLoader.load(extension_path)
 	var parent_script: Script = extension_script.get_base_script()
@@ -764,7 +764,7 @@ func _remove_extension(extension_path: String) -> void:
 	parent_script_extensions.erase(found_script_extension)
 
 	# Preparing the script to have all other extensions reapllied
-	_reset_extension(parent_script_path)
+	_remove_all_extensions(parent_script_path)
 
 	# Reapplying all the extensions without the removed one
 	for script_extension in parent_script_extensions:
@@ -772,7 +772,7 @@ func _remove_extension(extension_path: String) -> void:
 
 
 # Used to fully reset the provided script to a state prior of any extension
-func _reset_extension(parent_script_path: String) -> void:
+func _remove_all_extensions(parent_script_path: String) -> void:
 	# Check path to file exists
 	if not ModLoaderUtils.file_exists(parent_script_path):
 		ModLoaderUtils.log_error("The parent script path \"%s\" does not exist" % [parent_script_path], LOG_NAME)
@@ -823,7 +823,7 @@ func uninstall_script_extension(extension_script_path: String) -> void:
 
 	# Currently this is the only thing we do, but it is better to expose
 	# this function like this for further changes
-	_remove_extension(extension_script_path)
+	_remove_specific_extension(extension_script_path)
 
 
 # Register an array of classes to the global scope, since Godot only does that in the editor.

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -816,7 +816,7 @@ func _remove_all_extensions_from_script(parent_script_path: String) -> void:
 
 
 func _remove_all_extensions_from_all_scripts() -> void:
-	var _to_remove_scripts = _saved_scripts.duplicate()
+	var _to_remove_scripts: Dictionary = _saved_scripts.duplicate()
 	for script in _to_remove_scripts:
 		_remove_all_extensions_from_script(script)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -796,6 +796,13 @@ func _remove_all_extensions(parent_script_path: String) -> void:
 	_saved_scripts.erase(parent_script_path)
 
 
+func _clear_extensions() -> void:
+	var _to_remove_scripts = _saved_scripts.duplicate()
+	for script in _to_remove_scripts:
+		_remove_all_extensions(script)
+	print(_saved_scripts)
+
+
 # Helpers
 # =============================================================================
 


### PR DESCRIPTION
This enables people to reload mods at runtime, currently the only changes made by mods that will be reset by this are extensions, which is the major changing factor in most cases. Opens up for next PRs that can reset nodes and hopefully all changes that mod developers want to make. 
An example use case scenario would be: user downloads or updates mod, without needing to restart the whole game, the user could click a button in game that reloads all mods. Another example could be a mod that introduces in game mod downloading and updating, allowing for a better user experience.
This PR also renames 
`_remove_extension` > `_remove_specific_extension_from_script` and 
`_reset_extension` > `_remove_all_extensions_from_script` for easier functionality comprehension.
Adds a fix for #198 that returns null in a return void function.  