### PR TITLE
feat: Option to skip deprecated fatal error

### DIFF
--- a/addons/mod_loader/api/deprecated.gd
+++ b/addons/mod_loader/api/deprecated.gd
@@ -7,28 +7,37 @@ const LOG_NAME := "ModLoader:Deprecated"
 
 
 # A method has changed its name/class
-static func deprecated_changed(old_method: String, new_method: String, since_version: String, show_removal_note: bool = true):
-	ModLoaderUtils.log_fatal(str(
+static func deprecated_changed(old_method: String, new_method: String, since_version: String, show_removal_note: bool = true) -> void:
+	_deprecated_log(str(
 		"DEPRECATED: ",
 		"The method \"%s\" has been deprecated since version %s. " % [old_method, since_version],
 		"Please use \"%s\" instead. " % new_method,
 		"The old method will be removed with the next major update, and will break your code if not changed. " if show_removal_note else ""
-	), LOG_NAME)
+	))
 
 
 # A method has been entirely removed, with no replacement
 # (should never be needed but good to have just in case)
-static func deprecated_removed(old_method: String, since_version: String, show_removal_note: bool = true):
-	ModLoaderUtils.log_fatal(str(
+static func deprecated_removed(old_method: String, since_version: String, show_removal_note: bool = true) -> void:
+	_deprecated_log(str(
 		"DEPRECATED: ",
 		"The method \"%s\" has been deprecated since version %s, and is no longer available. " % [old_method, since_version],
 		"There is currently no replacement method. ",
 		"The method will be removed with the next major update, and will break your code if not changed. " if show_removal_note else ""
-	), LOG_NAME)
+	))
 
 
 # Freeform deprecation message.
 # Allows you to add a deprecation comment without specifying the old/new method
-static func deprecated_message(msg: String, since_version: String = ""):
+static func deprecated_message(msg: String, since_version: String = "") -> void:
 	var since_text := " (since version %s)" % since_version if since_version else ""
-	ModLoaderUtils.log_fatal(str("DEPRECATED: ", msg, since_text), LOG_NAME)
+	_deprecated_log(str("DEPRECATED: ", msg, since_text))
+
+
+# Internal func for logging with support to trigger warnings instead of fatal
+# errors
+static func _deprecated_log(msg: String) -> void:
+	if ModLoaderStore.ml_options.ignore_deprecated_errors:
+		ModLoaderUtils.log_warning(msg, LOG_NAME)
+	else:
+		ModLoaderUtils.log_fatal(msg, LOG_NAME)

--- a/addons/mod_loader/classes/options_profile.gd
+++ b/addons/mod_loader/classes/options_profile.gd
@@ -12,3 +12,4 @@ export (bool) var steam_workshop_enabled = false
 export (String, DIR) var override_path_to_mods = ""
 export (String, DIR) var override_path_to_configs = ""
 export (String, DIR) var override_path_to_workshop = ""
+export (bool) var ignore_deprecated_errors = false

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -47,6 +47,11 @@ var ml_options := {
 
 	# Can be used in the editor to load mods from your Steam workshop directory
 	override_path_to_workshop = "",
+
+	# If true, using deprecated funcs will trigger a warning, instead of a fatal
+	# error. This can be helpful when developing mods that depend on a mod that
+	# hasn't been updated to fix the deprecated issues yet
+	ignore_deprecated_errors = false,
 }
 
 


### PR DESCRIPTION
Slightly refactors `ModLoaderDeprecated` to support a new ML Option, which downgrades the fatal errors from deprecated methods to just warnings.

This is mainly to help existing mods transition to ML v6, considering major breaking changes like #208.

_Note: I know we agreed to concat strings with `+`  instead of `str` (in #166), and this file still uses `str`, but that can be handled in a different PR as this one is only focused on this feature._