### PR TITLE
chore: Add `.gitattributes` to allow AssetLib downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Git stuff
-/.gitattributes     										export-ignore
-/.gitignore         										export-ignore
-.github/            										export-ignore
-/README.md          										export-ignore
+/.gitattributes													export-ignore
+/.gitignore															export-ignore
+.github/																export-ignore
+/README.md															export-ignore
 
 # Tests
 test/																		export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,12 @@
 # Git stuff
-/.gitattributes													export-ignore
-/.gitignore															export-ignore
-.github/																export-ignore
-/README.md															export-ignore
+/.gitattributes                         export-ignore
+/.gitignore                             export-ignore
+.github/                                export-ignore
+/README.md                              export-ignore
 
 # Tests
-test/																		export-ignore
+test/                                   export-ignore
 
-# Files not required by AssetLib downloads
-addons/mod_loader/vendor/								export-ignore
-addons/mod_loader/mod_loader_setup.gd		export-ignore
+# Files not required by AssetLib downloads (provided via download for manual installers)
+addons/mod_loader/vendor/               export-ignore
+addons/mod_loader/mod_loader_setup.gd   export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Git stuff
+/.gitattributes     										export-ignore
+/.gitignore         										export-ignore
+.github/            										export-ignore
+/README.md          										export-ignore
+
+# Tests
+test/																		export-ignore
+
+# Files not required by AssetLib downloads
+addons/mod_loader/vendor/								export-ignore
+addons/mod_loader/mod_loader_setup.gd		export-ignore


### PR DESCRIPTION
To provide the mod loader on the Godot AssetLib we need to get rid of any third-party dependencies. Fortunately, we only need these tools for the self setup.