### PR TITLE
refactor: :recycle: Move `mod_data` `ModLoader` -> `ModLoaderStore`

### DIFF
--- a/addons/mod_loader/api/config.gd
+++ b/addons/mod_loader/api/config.gd
@@ -25,13 +25,13 @@ static func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dicti
 	var defaults := {}
 
 	# Invalid mod ID
-	if not ModLoader.mod_data.has(mod_dir_name):
+	if not ModLoaderStore.mod_data.has(mod_dir_name):
 		status_code = MLConfigStatus.INVALID_MOD_ID
 		status_msg = "Mod ID was invalid: %s" % mod_dir_name
 
 	# Mod ID is valid
 	if status_code == MLConfigStatus.OK:
-		var mod := ModLoader.mod_data[mod_dir_name] as ModData
+		var mod := ModLoaderStore.mod_data[mod_dir_name] as ModData
 		var config_data := mod.config
 		defaults = mod.manifest.config_defaults
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -14,6 +14,9 @@ const LOG_NAME = "ModLoader:Store"
 # Vars
 # =============================================================================
 
+# Stores data for every found/loaded mod
+var mod_data := {}
+
 # Set to false after ModLoader._init()
 # Helps to decide whether a script extension should go through the _handle_script_extensions process
 var is_initializing := true


### PR DESCRIPTION
# Move `mod_data` from `ModLoader` to `ModLoaderStore`

This moves `mod_data` from *mod_loader.gd* to *mod_loader_store.gd*, enabling easier access from different classes.

## Breaking

- Two mods in my list, because they directly access `ModLoader.mod_data`.
`if ModLoader.mod_data.keys().has("damiBenro-Junker")`
- The default mod menu in Brotato for the same reason.
`for key in ModLoader.mod_data:`

Opened #219 and #221 to prevent this in the future. 


<br />
<br />

---
*works towards #153*