### PR TITLE
refactor: :recycle: Move `mod_load_order` to `ModLoaderStore`

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -153,7 +153,7 @@ func _load_mods() -> void:
 		var _is_circular := _check_dependencies(mod)
 
 	# Sort mod_load_order by the importance score of the mod
-	ModLoaderStore.mod_load_order = _get_load_order(mod_data.values())
+	ModLoaderStore.mod_load_order = _get_load_order(ModLoaderStore.mod_data.values())
 
 	# Log mod order
 	var mod_i := 1

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -52,9 +52,6 @@ const LOG_NAME := "ModLoader"
 # Stores data for every found/loaded mod
 var mod_data := {}
 
-# Order for mods to be loaded in, set by `_get_load_order`
-var mod_load_order := []
-
 # Any mods that are missing their dependancies are added to this
 # Example property: "mod_id": ["dep_mod_id_0", "dep_mod_id_2"]
 var mod_missing_dependencies := {}
@@ -159,17 +156,17 @@ func _load_mods() -> void:
 		var _is_circular := _check_dependencies(mod)
 
 	# Sort mod_load_order by the importance score of the mod
-	mod_load_order = _get_load_order(mod_data.values())
+	ModLoaderStore.mod_load_order = _get_load_order(mod_data.values())
 
 	# Log mod order
 	var mod_i := 1
-	for mod in mod_load_order: # mod === mod_data
+	for mod in ModLoaderStore.mod_load_order: # mod === mod_data
 		mod = mod as ModData
 		ModLoaderLog.info("mod_load_order -> %s) %s" % [mod_i, mod.dir_name], LOG_NAME)
 		mod_i += 1
 
 	# Instance every mod and add it as a node to the Mod Loader
-	for mod in mod_load_order:
+	for mod in ModLoaderStore.mod_load_order:
 		mod = mod as ModData
 		ModLoaderLog.info("Initializing -> %s" % mod.manifest.get_mod_id(), LOG_NAME)
 		_init_mod(mod)
@@ -194,7 +191,7 @@ func _reload_mods() -> void:
 # Internal call that handles the resetting of all mod related data
 func _reset_mods() -> void:
 	mod_data.clear()
-	mod_load_order.clear()
+	ModLoaderStore.mod_load_order.clear()
 	mod_missing_dependencies.clear()
 	ModLoaderStore.script_extensions.clear()
 	_remove_all_extensions_from_all_scripts()
@@ -562,11 +559,11 @@ func _get_load_order(mod_data_array: Array) -> Array:
 	for mod in mod_data_array:
 		mod = mod as ModData
 		if mod.is_loadable:
-			mod_load_order.append(mod)
+			ModLoaderStore.mod_load_order.append(mod)
 
 	# Sort mods by the importance value
-	mod_load_order.sort_custom(self, "_compare_importance")
-	return  mod_load_order
+	ModLoaderStore.mod_load_order.sort_custom(self, "_compare_importance")
+	return  ModLoaderStore.mod_load_order
 
 
 # Custom sorter that orders mods by important
@@ -644,7 +641,7 @@ func _handle_script_extensions()->void:
 func _sort_extensions_from_load_order(extensions:Array)->Array:
 	var extensions_sorted := []
 
-	for _mod_data in mod_load_order:
+	for _mod_data in ModLoaderStore.mod_load_order:
 		for script in extensions:
 			if script.mod_id == _mod_data.dir_name:
 				extensions_sorted.push_front(script)

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -14,6 +14,9 @@ const LOG_NAME = "ModLoader:Store"
 # Vars
 # =============================================================================
 
+# Order for mods to be loaded in, set by `_get_load_order`
+var mod_load_order := []
+
 # Set to false after ModLoader._init()
 # Helps to decide whether a script extension should go through the _handle_script_extensions process
 var is_initializing := true


### PR DESCRIPTION
This moves `mod_load_order` from *mod_loader.gd* to *mod_loader_store.gd*, enabling easier access from different classes.

<br />
<br />

*works towards #153*