### PR TITLE
refactor: ♻️ move remaining vars to `ModLoaderStore`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -93,4 +93,4 @@ static func save_scene(modified_scene: Node, scene_path: String) -> void:
 	ModLoaderLog.debug("packing scene -> %s" % packed_scene, LOG_NAME)
 	packed_scene.take_over_path(scene_path)
 	ModLoaderLog.debug("save_scene - taking over path - new path -> %s" % packed_scene.resource_path, LOG_NAME)
-	ModLoader._saved_objects.append(packed_scene)
+	ModLoaderStore._saved_objects.append(packed_scene)

--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -93,4 +93,4 @@ static func save_scene(modified_scene: Node, scene_path: String) -> void:
 	ModLoaderLog.debug("packing scene -> %s" % packed_scene, LOG_NAME)
 	packed_scene.take_over_path(scene_path)
 	ModLoaderLog.debug("save_scene - taking over path - new path -> %s" % packed_scene.resource_path, LOG_NAME)
-	ModLoaderStore._saved_objects.append(packed_scene)
+	ModLoaderStore.saved_objects.append(packed_scene)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -59,9 +59,6 @@ var mod_load_order := []
 # Example property: "mod_id": ["dep_mod_id_0", "dep_mod_id_2"]
 var mod_missing_dependencies := {}
 
-# Store vanilla classes for script extension sorting
-var loaded_vanilla_parents_cache := {}
-
 # Stores all the taken over scripts for restoration
 var _saved_scripts := {}
 
@@ -615,8 +612,8 @@ func _handle_script_extensions()->void:
 		var parent_script:Script = child_script.get_base_script()
 		var parent_script_path:String = parent_script.resource_path
 
-		if not loaded_vanilla_parents_cache.keys().has(parent_script_path):
-			loaded_vanilla_parents_cache[parent_script_path] = parent_script
+		if not ModLoaderStore.loaded_vanilla_parents_cache.keys().has(parent_script_path):
+			ModLoaderStore.loaded_vanilla_parents_cache[parent_script_path] = parent_script
 
 		script_extension_data_array.push_back(
 			ScriptExtensionData.new(extension_path, parent_script_path, mod_id)
@@ -629,7 +626,7 @@ func _handle_script_extensions()->void:
 	script_extension_data_array.sort_custom(self, "check_inheritances")
 
 	# This saved some bugs in the past.
-	loaded_vanilla_parents_cache.clear()
+	ModLoaderStore.loaded_vanilla_parents_cache.clear()
 
 	# Load and install all extensions
 	for extension in script_extension_data_array:
@@ -654,11 +651,11 @@ func _sort_extensions_from_load_order(extensions:Array)->Array:
 func _check_inheritances(extension_a:ScriptExtensionData, extension_b:ScriptExtensionData)->bool:
 	var a_child_script:Script
 
-	if loaded_vanilla_parents_cache.keys().has(extension_a.parent_script_path):
+	if ModLoaderStore.loaded_vanilla_parents_cache.keys().has(extension_a.parent_script_path):
 		a_child_script = ResourceLoader.load(extension_a.parent_script_path)
 	else:
 		a_child_script = ResourceLoader.load(extension_a.parent_script_path)
-		loaded_vanilla_parents_cache[extension_a.parent_script_path] = a_child_script
+		ModLoaderStore.loaded_vanilla_parents_cache[extension_a.parent_script_path] = a_child_script
 
 	var a_parent_script:Script = a_child_script.get_base_script()
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -59,9 +59,6 @@ var mod_load_order := []
 # Example property: "mod_id": ["dep_mod_id_0", "dep_mod_id_2"]
 var mod_missing_dependencies := {}
 
-# Things to keep to ensure they are not garbage collected (used by `save_scene`)
-var _saved_objects := []
-
 # Store vanilla classes for script extension sorting
 var loaded_vanilla_parents_cache := {}
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -27,6 +27,9 @@ var has_shown_editor_zips_warning := false
 # Things to keep to ensure they are not garbage collected (used by `save_scene`)
 var _saved_objects := []
 
+# Store vanilla classes for script extension sorting
+var loaded_vanilla_parents_cache := {}
+
 # Keeps track of logged messages, to avoid flooding the log with duplicate notices
 # Can also be used by mods, eg. to create an in-game developer console that
 # shows messages

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -24,6 +24,9 @@ var script_extensions := []
 # True if ModLoader has displayed the warning about using zipped mods
 var has_shown_editor_zips_warning := false
 
+# Things to keep to ensure they are not garbage collected (used by `save_scene`)
+var _saved_objects := []
+
 # Keeps track of logged messages, to avoid flooding the log with duplicate notices
 # Can also be used by mods, eg. to create an in-game developer console that
 # shows messages

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -25,7 +25,7 @@ var script_extensions := []
 var has_shown_editor_zips_warning := false
 
 # Things to keep to ensure they are not garbage collected (used by `save_scene`)
-var _saved_objects := []
+var saved_objects := []
 
 # Store vanilla classes for script extension sorting
 var loaded_vanilla_parents_cache := {}

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -30,6 +30,9 @@ var _saved_objects := []
 # Store vanilla classes for script extension sorting
 var loaded_vanilla_parents_cache := {}
 
+# Stores all the taken over scripts for restoration
+var saved_scripts := {}
+
 # Keeps track of logged messages, to avoid flooding the log with duplicate notices
 # Can also be used by mods, eg. to create an in-game developer console that
 # shows messages


### PR DESCRIPTION
Moves the remaining vars from *mod_loader.gd* to *mod_loader_store.gd*.

- `_saved_objects` ( renamed to `saved_objects` )
- `loaded_vanilla_parents_cache`
- `_saved_scripts` ( renamed to `saved_scripts` )

<br />
<br />

*works towards #153*