### PR TITLE
refactor: ♻️ move consts from `ModLoader` to `ModLoaderStore`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -94,3 +94,7 @@ static func save_scene(modified_scene: Node, scene_path: String) -> void:
 	packed_scene.take_over_path(scene_path)
 	ModLoaderLog.debug("save_scene - taking over path - new path -> %s" % packed_scene.resource_path, LOG_NAME)
 	ModLoaderStore.saved_objects.append(packed_scene)
+
+
+static func get_unpacked_dir() -> String:
+	return _ModLoaderPath.get_unpacked_mods_dir_path()

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -114,6 +114,9 @@ static func get_path_to_mods() -> String:
 	return mods_folder_path
 
 
+static func get_unpacked_mods_dir_path() -> String:
+	return ModLoaderStore.UNPACKED_DIR
+
 # Get the path to the configs folder, with any applicable overrides applied
 static func get_path_to_configs() -> String:
 	var configs_path := MOD_CONFIG_DIR_PATH

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -11,7 +11,7 @@ const LOG_NAME := "ModLoader:ScriptExtension"
 # Couple the extension paths with the parent paths and the extension's mod id
 # in a ScriptExtensionData resource
 # We need to pass the UNPACKED_DIR constant because the global ModLoader is not available during _init().
-static func handle_script_extensions(UNPACKED_DIR: String) -> void:
+static func handle_script_extensions() -> void:
 	var script_extension_data_array := []
 	for extension_path in ModLoaderStore.script_extensions:
 
@@ -21,7 +21,7 @@ static func handle_script_extensions(UNPACKED_DIR: String) -> void:
 
 		var child_script = ResourceLoader.load(extension_path)
 
-		var mod_id: String = extension_path.trim_prefix(UNPACKED_DIR).get_slice("/", 0)
+		var mod_id: String = extension_path.trim_prefix(ModLoaderStore.UNPACKED_DIR).get_slice("/", 0)
 
 		var parent_script: Script = child_script.get_base_script()
 		var parent_script_path: String = parent_script.resource_path

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -25,6 +25,10 @@ signal logged(entry)
 # Prefix for this file when using mod_log or dev_log
 const LOG_NAME := "ModLoader"
 
+# --- DEPRECATED ---
+# UNPACKED_DIR was moved to ModLoaderStore.
+# However, many Brotato mods use this const directly, which is why the deprecation warning was added.
+var UNPACKED_DIR := "res://mods-unpacked/" setget ,deprecated_direct_access_UNPACKED_DIR
 
 # Main
 # =============================================================================
@@ -466,3 +470,8 @@ func save_scene(modified_scene: Node, scene_path: String) -> void:
 func get_mod_config(mod_dir_name: String = "", key: String = "") -> Dictionary:
 	ModLoaderDeprecated.deprecated_changed("ModLoader.get_mod_config", "ModLoaderConfig.get_mod_config", "6.0.0")
 	return ModLoaderConfig.get_mod_config(mod_dir_name, key)
+
+
+func deprecated_direct_access_UNPACKED_DIR() -> String:
+	ModLoaderDeprecated.deprecated_message("The const \"UNPACKED_DIR\" was removed, use \"ModLoaderMod.get_unpacked_dir()\" instead", "6.0.0")
+	return _ModLoaderPath.get_unpacked_mods_dir_path()

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -22,26 +22,6 @@ extends Node
 
 signal logged(entry)
 
-# Config
-# =============================================================================
-
-# Most of these settings should never need to change, aside from the DEBUG_*
-# options (which should be `false` when distributing compiled PCKs)
-
-const MODLOADER_VERSION = "5.0.1"
-
-# If true, a complete array of filepaths is stored for each mod. This is
-# disabled by default because the operation can be very expensive, but may
-# be useful for debugging
-const DEBUG_ENABLE_STORING_FILEPATHS := false
-
-# This is where mod ZIPs are unpacked to
-const UNPACKED_DIR := "res://mods-unpacked/"
-
-
-# Set to true to require using "--enable-mods" to enable them
-const REQUIRE_CMD_LINE := false
-
 # Prefix for this file when using mod_log or dev_log
 const LOG_NAME := "ModLoader"
 
@@ -51,7 +31,7 @@ const LOG_NAME := "ModLoader"
 
 func _init() -> void:
 	# if mods are not enabled - don't load mods
-	if REQUIRE_CMD_LINE and not _ModLoaderCLI.is_running_with_command_line_arg("--enable-mods"):
+	if ModLoaderStore.REQUIRE_CMD_LINE and not _ModLoaderCLI.is_running_with_command_line_arg("--enable-mods"):
 		return
 
 	# Rotate the log files once on startup. Can't be checked in utils, since it's static
@@ -155,7 +135,7 @@ func _load_mods() -> void:
 
 	ModLoaderLog.success("DONE: Completely finished loading mods", LOG_NAME)
 
-	_ModLoaderScriptExtension.handle_script_extensions(UNPACKED_DIR)
+	_ModLoaderScriptExtension.handle_script_extensions()
 
 	ModLoaderLog.success("DONE: Installed all script extensions", LOG_NAME)
 
@@ -256,8 +236,8 @@ func _load_zips_in_folder(folder_path: String) -> int:
 		if OS.has_feature("editor") and not ModLoaderStore.has_shown_editor_zips_warning:
 			ModLoaderLog.warning(str(
 				"Loading any resource packs (.zip/.pck) with `load_resource_pack` will WIPE the entire virtual res:// directory. ",
-				"If you have any unpacked mods in ", UNPACKED_DIR, ", they will not be loaded. ",
-				"Please unpack your mod ZIPs instead, and add them to ", UNPACKED_DIR), LOG_NAME)
+				"If you have any unpacked mods in ", ModLoaderStore.UNPACKED_DIR, ", they will not be loaded. ",
+				"Please unpack your mod ZIPs instead, and add them to ", ModLoaderStore.UNPACKED_DIR), LOG_NAME)
 			ModLoaderStore.has_shown_editor_zips_warning = true
 
 		ModLoaderLog.debug("Found mod ZIP: %s" % mod_folder_global_path, LOG_NAME)
@@ -324,7 +304,7 @@ func _load_steam_workshop_zips() -> int:
 # which adds their data to mod_data.
 func _setup_mods() -> int:
 	# Path to the unpacked mods folder
-	var unpacked_mods_path := UNPACKED_DIR
+	var unpacked_mods_path := ModLoaderStore.UNPACKED_DIR
 
 	var dir := Directory.new()
 	if not dir.open(unpacked_mods_path) == OK:
@@ -414,7 +394,7 @@ func _init_mod_data(mod_folder_path: String) -> void:
 	var dir_name := _ModLoaderPath.get_file_name_from_path(mod_folder_path, false, true)
 
 	# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
-	var local_mod_path := UNPACKED_DIR.plus_file(dir_name)
+	var local_mod_path := ModLoaderStore.UNPACKED_DIR.plus_file(dir_name)
 
 	var mod := ModData.new(local_mod_path)
 	mod.dir_name = dir_name
@@ -427,7 +407,7 @@ func _init_mod_data(mod_folder_path: String) -> void:
 	# not needed anymore. It can be useful when debugging, but it's also an expensive
 	# operation if a mod has a large number of files (eg. Brotato's Invasion mod,
 	# which has ~1,000 files). That's why it's disabled by default
-	if DEBUG_ENABLE_STORING_FILEPATHS:
+	if ModLoaderStore.DEBUG_ENABLE_STORING_FILEPATHS:
 		mod.file_paths = _ModLoaderPath.get_flat_view_dict(local_mod_path)
 
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -9,6 +9,22 @@ extends Node
 # Constants
 # =============================================================================
 
+# Most of these settings should never need to change, aside from the DEBUG_*
+# options (which should be `false` when distributing compiled PCKs)
+
+const MODLOADER_VERSION = "5.0.1"
+
+# If true, a complete array of filepaths is stored for each mod. This is
+# disabled by default because the operation can be very expensive, but may
+# be useful for debugging
+const DEBUG_ENABLE_STORING_FILEPATHS := false
+
+# This is where mod ZIPs are unpacked to
+const UNPACKED_DIR := "res://mods-unpacked/"
+
+# Set to true to require using "--enable-mods" to enable them
+const REQUIRE_CMD_LINE := false
+
 const LOG_NAME = "ModLoader:Store"
 
 # Vars


### PR DESCRIPTION
## Move `const`s from `ModLoader` to `ModLoaderStore`

### Disclaimer
Not sure if we should do this. Moving `const UNPACKED_DIR` will break a lot of Brotato Mods because they use this pattern in there *mod_main.gd* most of the time:
`dir = modLoader.UNPACKED_DIR + "Darkly77-ContentLoader/"`

And I don't think there is a good way to add a deprecation warning to a `const`?

---

- Moved to `ModLoaderStore`:
   - `MODLOADER_VERSION`
   - `DEBUG_ENABLE_STORING_FILEPATHS`
   - `UNPACKED_DIR`
   - `REQUIRE_CMD_LINE`
- Added `get_unpacked_dir()` to `ModLoaderMod`
- Added `get_unpacked_mods_dir_path()` to `_ModLoaderPath`

<br/>

*works towards https://github.com/GodotModding/godot-mod-loader/issues/153*