### PR TITLE
fix: 🐛 wrong `UNPACKED_DIR` reference

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -194,7 +194,7 @@ static func _update_mod_lists() -> bool:
 		# Delete no longer installed mods
 		for mod_id in profile.mod_list:
 			# Check if the mod_dir for the mod-id exists
-			if not _ModLoaderFile.dir_exists(ModLoader.UNPACKED_DIR + mod_id):
+			if not _ModLoaderFile.dir_exists(_ModLoaderPath.get_unpacked_mods_dir_path() + mod_id):
 				# if not the mod is no longer installed and can be removed
 				profile.mod_list.erase(mod_id)
 

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -21,7 +21,7 @@ static func handle_script_extensions() -> void:
 
 		var child_script = ResourceLoader.load(extension_path)
 
-		var mod_id: String = extension_path.trim_prefix(ModLoaderStore.UNPACKED_DIR).get_slice("/", 0)
+		var mod_id: String = extension_path.trim_prefix(_ModLoaderPath.get_unpacked_mods_dir_path()).get_slice("/", 0)
 
 		var parent_script: Script = child_script.get_base_script()
 		var parent_script_path: String = parent_script.resource_path

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -10,7 +10,6 @@ const LOG_NAME := "ModLoader:ScriptExtension"
 
 # Couple the extension paths with the parent paths and the extension's mod id
 # in a ScriptExtensionData resource
-# We need to pass the UNPACKED_DIR constant because the global ModLoader is not available during _init().
 static func handle_script_extensions() -> void:
 	var script_extension_data_array := []
 	for extension_path in ModLoaderStore.script_extensions:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -255,8 +255,8 @@ func _load_zips_in_folder(folder_path: String) -> int:
 		if OS.has_feature("editor") and not ModLoaderStore.has_shown_editor_zips_warning:
 			ModLoaderLog.warning(str(
 				"Loading any resource packs (.zip/.pck) with `load_resource_pack` will WIPE the entire virtual res:// directory. ",
-				"If you have any unpacked mods in ", ModLoaderStore.UNPACKED_DIR, ", they will not be loaded. ",
-				"Please unpack your mod ZIPs instead, and add them to ", ModLoaderStore.UNPACKED_DIR), LOG_NAME)
+				"If you have any unpacked mods in ", _ModLoaderPath.get_unpacked_mods_dir_path(), ", they will not be loaded. ",
+				"Please unpack your mod ZIPs instead, and add them to ", _ModLoaderPath.get_unpacked_mods_dir_path()), LOG_NAME)
 			ModLoaderStore.has_shown_editor_zips_warning = true
 
 		ModLoaderLog.debug("Found mod ZIP: %s" % mod_folder_global_path, LOG_NAME)
@@ -323,7 +323,7 @@ func _load_steam_workshop_zips() -> int:
 # which adds their data to mod_data.
 func _setup_mods() -> int:
 	# Path to the unpacked mods folder
-	var unpacked_mods_path := ModLoaderStore.UNPACKED_DIR
+	var unpacked_mods_path := _ModLoaderPath.get_unpacked_mods_dir_path()
 
 	var dir := Directory.new()
 	if not dir.open(unpacked_mods_path) == OK:
@@ -413,7 +413,7 @@ func _init_mod_data(mod_folder_path: String) -> void:
 	var dir_name := _ModLoaderPath.get_file_name_from_path(mod_folder_path, false, true)
 
 	# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
-	var local_mod_path := ModLoaderStore.UNPACKED_DIR.plus_file(dir_name)
+	var local_mod_path := _ModLoaderPath.get_unpacked_mods_dir_path().plus_file(dir_name)
 
 	var mod := ModData.new(local_mod_path)
 	mod.dir_name = dir_name


### PR DESCRIPTION
- Corrected an error in `ModLoaderUserProfile` where `UNPACKED_DIR` was incorrectly referenced to `ModLoader`.
- Updated all other references to `UNPACKED_DIR` to use `_ModLoaderPath.get_unpacked_mods_dir_path()`
- Removed the comment that was added to `handle_script_extensions()` function before the `UNPACKED_DIR` const was moved to `ModLoaderStore`.