### PR TITLE
refactor: ♻️ Ignore hidden directories

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -350,15 +350,14 @@ func _setup_mods() -> int:
 			# Stop loading mod zip files
 			break
 
-		# Only check directories
-		if not dir.current_is_dir():
-			continue
-
-		if mod_dir_name == "." or mod_dir_name == "..":
-			continue
-
-		# Ignore hidden directories
-		if mod_dir_name.begins_with("."):
+		if (
+			# Only check directories
+			not dir.current_is_dir()
+			# Ignore self and hidden directories
+			or mod_dir_name.begins_with(".")
+			# Ignore parent directory link
+			or mod_dir_name == ".."
+		):
 			continue
 
 		if ModLoaderStore.ml_options.disabled_mods.has(mod_dir_name):

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -353,10 +353,8 @@ func _setup_mods() -> int:
 		if (
 			# Only check directories
 			not dir.current_is_dir()
-			# Ignore self and hidden directories
+			# Ignore self, parent and hidden directories
 			or mod_dir_name.begins_with(".")
-			# Ignore parent directory link
-			or mod_dir_name == ".."
 		):
 			continue
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -357,6 +357,10 @@ func _setup_mods() -> int:
 		if mod_dir_name == "." or mod_dir_name == "..":
 			continue
 
+		# Ignore hidden directories
+		if mod_dir_name.begins_with("."):
+			continue
+
 		if ModLoaderStore.ml_options.disabled_mods.has(mod_dir_name):
 			ModLoaderLog.info("Skipped setting up mod: \"%s\"" % mod_dir_name, LOG_NAME)
 			continue


### PR DESCRIPTION
Currently the mod loader will try to read hidden directories (such as .git) as if they were mods and then throw assertion errors. This just adds a small check to stop that