### PR TITLE
fix: :pencil2: removed reference to manifest in error message

### DIFF
--- a/addons/mod_loader/internal/mod_loader_utils.gd
+++ b/addons/mod_loader/internal/mod_loader_utils.gd
@@ -55,7 +55,7 @@ static func dict_has_fields(dict: Dictionary, required_fields: Array) -> bool:
 			missing_fields.erase(key)
 
 	if missing_fields.size() > 0:
-		ModLoaderLog.fatal("Mod manifest is missing required fields: %s" % missing_fields, LOG_NAME)
+		ModLoaderLog.fatal("Dictionary is missing required fields: %s" % missing_fields, LOG_NAME)
 		return false
 
 	return true


### PR DESCRIPTION

- removed reference to manifest in the error message because it is now in the general utils.

closes #253