### PR TITLE
refactor: :recycle: store Profile object instead of  profile name

### DIFF
--- a/addons/mod_loader/api/config.gd
+++ b/addons/mod_loader/api/config.gd
@@ -322,14 +322,14 @@ static func get_current_config(mod_id: String) -> ModConfig:
 # The currently active configuration name for the given mod id or an empty string if not found.
 static func get_current_config_name(mod_id: String) -> String:
 	# Check if user profile has been loaded
-	if not ModLoaderStore.user_profiles.has(ModLoaderStore.current_user_profile):
+	if not ModLoaderStore.user_profiles.has(ModLoaderStore.current_user_profile.name):
 		# Warn and return an empty string if the user profile has not been loaded
 		ModLoaderLog.warning("Can't get current mod config for \"%s\", because no current user profile is present." % mod_id, LOG_NAME)
 		return ""
 
 	# Retrieve the current user profile from ModLoaderStore
 	# *Can't use ModLoaderUserProfile because it causes a cyclic dependency*
-	var current_user_profile = ModLoaderStore.user_profiles[ModLoaderStore.current_user_profile]
+	var current_user_profile = ModLoaderStore.current_user_profile
 
 	# Check if the mod exists in the user profile's mod list and if it has a current config
 	if not current_user_profile.mod_list.has(mod_id) or not current_user_profile.mod_list[mod_id].has("current_config"):

--- a/addons/mod_loader/classes/mod_data.gd
+++ b/addons/mod_loader/classes/mod_data.gd
@@ -105,7 +105,7 @@ func _load_config(config_file_path: String) -> void:
 
 # Update the mod_list of the current user profile
 func _set_current_config(new_current_config: ModConfig) -> void:
-	ModLoaderUserProfile.set_mod_current_config(dir_name, new_current_config.name)
+	ModLoaderUserProfile.set_mod_current_config(dir_name, new_current_config)
 	current_config = new_current_config
 	ModLoader.emit_signal("current_config_changed", new_current_config)
 

--- a/addons/mod_loader/classes/mod_user_profile.gd
+++ b/addons/mod_loader/classes/mod_user_profile.gd
@@ -1,0 +1,13 @@
+extends Resource
+class_name ModUserProfile
+
+
+# This Class is used to represent a User Profile for the ModLoader.
+
+var name := ""
+var mod_list := {}
+
+
+func _init(_name := "", _mod_list := {}) -> void:
+	name = _name
+	mod_list = _mod_list

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -82,7 +82,7 @@ var logged_messages := {
 }
 
 # Active user profile
-var current_user_profile := ""
+var current_user_profile: ModUserProfile
 # List of user profiles loaded from user://mods.json
 var user_profiles :=  {}
 


### PR DESCRIPTION
This will make it easier to access all profile data of the current profile. Before, you always had to get the profile data from `ModLoaderStore.user_profiles`.

- Removed the sub Class `Profile` in `ModLoaderUserProfile`
- Added new Resource Class `ModUserProfile`

To allow setting the type in `ModLoaderStore` without causing a cyclic dependency.

<br/>
<br/>

closes #247