### PR TITLE
refactor: :recycle: remove `incompatibilities` from required keys

### DIFF
--- a/addons/mod_loader/classes/mod_manifest.gd
+++ b/addons/mod_loader/classes/mod_manifest.gd
@@ -52,7 +52,6 @@ const REQUIRED_MANIFEST_KEYS_EXTRA = [
 	"authors",
 	"compatible_mod_loader_version",
 	"compatible_game_version",
-	"incompatibilities",
 ]
 
 


### PR DESCRIPTION
- Removes `"incompatibilities"` from `REQUIRED_MANIFEST_KEYS_EXTRA`
No need to pass an empty array if you don't need it. 

<br/>
closes #242