### PR TITLE
feat: ✨ option to allow autoload placement anywhere

### DIFF
--- a/addons/mod_loader/classes/options_profile.gd
+++ b/addons/mod_loader/classes/options_profile.gd
@@ -9,6 +9,7 @@ export (bool) var enable_mods = true
 export (Array, String) var locked_mods = []
 export (ModLoaderLog.VERBOSITY_LEVEL) var log_level := ModLoaderLog.VERBOSITY_LEVEL.DEBUG
 export (Array, String) var disabled_mods = []
+export (bool) var allow_modloader_autoloads_anywhere = false
 export (bool) var steam_workshop_enabled = false
 export (String, DIR) var override_path_to_mods = ""
 export (String, DIR) var override_path_to_configs = ""

--- a/addons/mod_loader/internal/godot.gd
+++ b/addons/mod_loader/internal/godot.gd
@@ -39,19 +39,23 @@ static func check_autoload_order(autoload_name_before: String, autoload_name_aft
 # Check the index position of the provided autoload (0 = 1st, 1 = 2nd, etc).
 # Returns a bool if the position does not match.
 # Optionally triggers a fatal error
-static func check_autoload_position(autoload_name: String, position_index: int, trigger_error: bool = false) -> bool:
+static func check_autoload_position(autoload_name: String, position_index: int, trigger_error := false) -> bool:
 	var autoload_array := get_autoload_array()
 	var autoload_index := autoload_array.find(autoload_name)
 	var position_matches := autoload_index == position_index
 
 	if not position_matches and trigger_error:
-		var error_msg := "Expected %s to be the autoload in position %s, but this is currently %s." % [autoload_name, str(position_index + 1), autoload_array[position_index]]
-		var help_msg := ""
+		var error_msg := (
+			"Expected %s to be the autoload in position %s, but this is currently %s. "
+			% [autoload_name, str(position_index + 1), autoload_array[position_index]]
+		)
+		var help_msg := AUTOLOAD_CONFIG_HELP_MSG if OS.has_feature("editor") else ""
+		var final_message = error_msg + help_msg
 
-		if OS.has_feature("editor"):
-			help_msg = " To configure your autoloads, go to Project > Project Settings > Autoload."
-
-		ModLoaderLog.fatal(error_msg + help_msg, LOG_NAME)
+		push_error(final_message)
+		ModLoaderLog._write_to_log_file(final_message)
+		ModLoaderLog._write_to_log_file(JSON.print(get_stack(), "  "))
+		assert(false, final_message)
 
 	return position_matches
 

--- a/addons/mod_loader/internal/godot.gd
+++ b/addons/mod_loader/internal/godot.gd
@@ -6,6 +6,34 @@ extends Object
 # Currently all of the included methods are internal and should only be used by the mod loader itself.
 
 const LOG_NAME := "ModLoader:Godot"
+const AUTOLOAD_CONFIG_HELP_MSG := "To configure your autoloads, go to Project > Project Settings > Autoload."
+
+
+# Check if autoload_name_before is before autoload_name_after
+# Returns a bool if the position does not match.
+# Optionally triggers a fatal error
+static func check_autoload_order(autoload_name_before: String, autoload_name_after: String, trigger_error := false) -> bool:
+	var autoload_name_before_index := get_autoload_index(autoload_name_before)
+	var autoload_name_after_index := get_autoload_index(autoload_name_after)
+
+	# Check if the Store is before the ModLoader
+	if not autoload_name_before_index < autoload_name_after_index:
+		var error_msg := (
+			"Expected %s ( position: %s ) to be loaded before %s ( position: %s ). "
+			% [autoload_name_before, autoload_name_before_index, autoload_name_after, autoload_name_after_index]
+		)
+		var help_msg := AUTOLOAD_CONFIG_HELP_MSG if OS.has_feature("editor") else ""
+
+		if trigger_error:
+			var final_message = error_msg + help_msg
+			push_error(final_message)
+			ModLoaderLog._write_to_log_file(final_message)
+			ModLoaderLog._write_to_log_file(JSON.print(get_stack(), "  "))
+			assert(false, final_message)
+
+		return false
+
+	return true
 
 
 # Check the index position of the provided autoload (0 = 1st, 1 = 2nd, etc).
@@ -39,3 +67,11 @@ static func get_autoload_array() -> Array:
 			autoloads.append(name.trim_prefix("autoload/"))
 
 	return autoloads
+
+
+# Get the index of a specific autoload
+static func get_autoload_index(autoload_name: String) -> int:
+	var autoloads := get_autoload_array()
+	var autoload_index := autoloads.find(autoload_name)
+
+	return autoload_index

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -35,15 +35,15 @@ var UNPACKED_DIR := "res://mods-unpacked/" setget ,deprecated_direct_access_UNPA
 # =============================================================================
 
 func _init() -> void:
+	# Ensure the ModLoaderStore and ModLoader autoloads are in the correct position.
+	_check_autoload_positions()
+
 	# if mods are not enabled - don't load mods
 	if ModLoaderStore.REQUIRE_CMD_LINE and not _ModLoaderCLI.is_running_with_command_line_arg("--enable-mods"):
 		return
 
 	# Rotate the log files once on startup. Can't be checked in utils, since it's static
 	ModLoaderLog._rotate_log_file()
-
-	# Ensure ModLoaderStore and ModLoader are the 1st and 2nd autoloads
-	_check_autoload_positions()
 
 	# Log the autoloads order. Helpful when providing support to players
 	ModLoaderLog.debug_json_print("Autoload order", _ModLoaderGodot.get_autoload_array(), LOG_NAME)
@@ -188,16 +188,23 @@ func _disable_mods() -> void:
 # Check autoload positions:
 # Ensure 1st autoload is `ModLoaderStore`, and 2nd is `ModLoader`.
 func _check_autoload_positions() -> void:
-	# If the override file exists we assume the ModLoader was setup with the --setup-create-override-cfg cli arg
-	# In that case the ModLoader will be the last entry in the autoload array
+	var ml_options: Object = preload("res://addons/mod_loader/options/options.tres").current_options
 	var override_cfg_path := _ModLoaderPath.get_override_path()
 	var is_override_cfg_setup :=  _ModLoaderFile.file_exists(override_cfg_path)
+	# If the override file exists we assume the ModLoader was setup with the --setup-create-override-cfg cli arg
+	# In that case the ModLoader will be the last entry in the autoload array
 	if is_override_cfg_setup:
 		ModLoaderLog.info("override.cfg setup detected, ModLoader will be the last autoload loaded.", LOG_NAME)
 		return
 
-	var _pos_ml_store := _ModLoaderGodot.check_autoload_position("ModLoaderStore", 0, true)
-	var _pos_ml_core := _ModLoaderGodot.check_autoload_position("ModLoader", 1, true)
+	# If there are Autoloads that need to be before the ModLoader
+	# "allow_modloader_autoloads_anywhere" in the ModLoader Options can be enabled.
+	# With that only the correct order of, ModLoaderStore first and ModLoader second, is checked.
+	if ml_options.allow_modloader_autoloads_anywhere:
+		_ModLoaderGodot.check_autoload_order("ModLoaderStore", "ModLoader", true)
+	else:
+		var _pos_ml_store := _ModLoaderGodot.check_autoload_position("ModLoaderStore", 0, true)
+		var _pos_ml_core := _ModLoaderGodot.check_autoload_position("ModLoader", 1, true)
 
 
 # Loop over "res://mods" and add any mod zips to the unpacked virtual directory

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -104,6 +104,10 @@ var ml_options := {
 	# Array of disabled mods (contains mod IDs as strings)
 	disabled_mods = [],
 
+	# If this flag is set to true, the ModLoaderStore and ModLoader Autoloads don't have to be the first Autoloads.
+	# The ModLoaderStore Autoload still needs to be placed before the ModLoader Autoload.
+	allow_modloader_autoloads_anywhere = false,
+
 	# If true, ModLoader will load mod ZIPs from the Steam workshop directory,
 	# instead of the default location (res://mods)
 	steam_workshop_enabled = false,


### PR DESCRIPTION
To make things work when `ModLoaderStore` is not placed before `ModLoader`, I had to move the check to the beginning of the `_init()` function. To handle the problem in `check_autoload_order()`, where I couldn't use `ModLoaderLog.fatal()` due to its reliance on a function that references `ModLoaderStore`, I directly loaded the ModLoader Options resource in `_check_autoload_positions()`. Check out issue https://github.com/GodotModding/godot-mod-loader/issues/262 for more info.

Did the same fix for `check_autoload_position()` to allow the error logging without `ModLoaderStore`

<br/>
<br/>

closes #257
closes #262 