### PR TITLE
fix: :bug: removed `dir_exists()` check

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -149,13 +149,11 @@ static func get_path_to_configs() -> String:
 
 
 # Get the path to a mods config folder
-# Returns an empty string if there is no config dir for this mod_id
 static func get_path_to_mod_configs_dir(mod_id: String) -> String:
 	return get_path_to_configs().plus_file(mod_id)
 
 
 # Get the path to a mods config file
-# Returns an empty string if the config file does not exist.
 static func get_path_to_mod_config_file(mod_id: String, config_name: String) -> String:
 	var mod_config_dir := get_path_to_mod_configs_dir(mod_id)
 

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -151,13 +151,7 @@ static func get_path_to_configs() -> String:
 # Get the path to a mods config folder
 # Returns an empty string if there is no config dir for this mod_id
 static func get_path_to_mod_configs_dir(mod_id: String) -> String:
-	var mod_config_dir := get_path_to_configs().plus_file(mod_id)
-
-	# Can't use _ModLoaderFile because of cyclic dependency.
-	if not Directory.new().dir_exists(mod_config_dir):
-		return ""
-
-	return mod_config_dir
+	return get_path_to_configs().plus_file(mod_id)
 
 
 # Get the path to a mods config file
@@ -165,13 +159,4 @@ static func get_path_to_mod_configs_dir(mod_id: String) -> String:
 static func get_path_to_mod_config_file(mod_id: String, config_name: String) -> String:
 	var mod_config_dir := get_path_to_mod_configs_dir(mod_id)
 
-	if mod_config_dir.empty():
-		return ""
-
-	var mod_config_file_dir := mod_config_dir.plus_file( config_name + ".json")
-
-	# Can't use _ModLoaderFile because of cyclic dependency.
-	if not Directory.new().file_exists(mod_config_file_dir):
-		return ""
-
-	return mod_config_file_dir
+	return mod_config_dir.plus_file( config_name + ".json")

--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -195,10 +195,11 @@ func to_json() -> String:
 
 # Loads the default configuration for a mod.
 func load_mod_config_defaults() -> ModConfig:
+	var default_config_save_path := _ModLoaderPath.get_path_to_mod_config_file(get_mod_id(), ModLoaderConfig.DEFAULT_CONFIG_NAME)
 	var config := ModConfig.new(
 		get_mod_id(),
 		{},
-		_ModLoaderPath.get_path_to_mod_config_file(get_mod_id(), ModLoaderConfig.DEFAULT_CONFIG_NAME),
+		default_config_save_path,
 		config_schema
 	)
 


### PR DESCRIPTION
With this change, these functions will always return the full path to the config file/dir, even if the parent directory doesn't exist. Usually, this directory will be created later when the file is saved.

closes #267