### PR TITLE
style: :pencil2: `add_translation_from_resource` to `add_translation`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -91,7 +91,7 @@ static func register_global_classes_from_array(new_global_classes: Array) -> voi
 # Add a translation file, eg "mytranslation.en.translation". The translation
 # file should have been created in Godot already: When you import a CSV, such
 # a file will be created for you.
-static func add_translation_from_resource(resource_path: String) -> void:
+static func add_translation(resource_path: String) -> void:
 	if not _ModLoaderFile.file_exists(resource_path):
 		ModLoaderLog.fatal("Tried to load a translation resource from a file that doesn't exist. The invalid path was: %s" % [resource_path], LOG_NAME)
 		return

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -364,8 +364,8 @@ func register_global_classes_from_array(new_global_classes: Array) -> void:
 
 
 func add_translation_from_resource(resource_path: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.add_translation_from_resource", "ModLoaderMod.add_translation_from_resource", "6.0.0")
-	ModLoaderMod.add_translation_from_resource(resource_path)
+	ModLoaderDeprecated.deprecated_changed("ModLoader.add_translation_from_resource", "ModLoaderMod.add_translation", "6.0.0")
+	ModLoaderMod.add_translation(resource_path)
 
 
 func append_node_in_scene(modified_scene: Node, node_name: String = "", node_parent = null, instance_path: String = "", is_visible: bool = true) -> void:


### PR DESCRIPTION
We removed the old way of adding translations a while back and now only have the `add_translation_from_resource(resource_path: String)` method, so we can simply rename it to `add_translation(resource_path: String)`.