### PR TITLE
build: :fire: remove git modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-	[submodule "addons/JSONConfigFile"]
-	path = addons/JSON_Schema_Validator
-	url = https://github.com/GodotModding/JSON-Shema-validator.git


### PR DESCRIPTION
Since submodules are not included in the zip download, we need to remove the submodule for the JSON Schema Validator. For more details, refer to https://github.com/dear-github/dear-github/issues/214.