### PR TITLE
fix: :bug: added `get_mod_data_all()`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -110,6 +110,11 @@ static func get_mod_data(mod_id: String) -> ModData:
 	return ModLoaderStore.mod_data[mod_id]
 
 
+# Gets the ModData of all loaded Mods as Dictionary.
+static func get_mod_data_all() -> Dictionary:
+	return ModLoaderStore.mod_data
+
+
 # Returns true if the mod with the given mod_id was successfully loaded.
 static func is_mod_loaded(mod_id: String) -> bool:
 	if ModLoaderStore.is_initializing:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -389,5 +389,5 @@ func deprecated_direct_access_UNPACKED_DIR() -> String:
 
 
 func deprecated_direct_access_mod_data() -> Dictionary:
-	ModLoaderDeprecated.deprecated_message("The var \"mod_data\" was removed, use \"ModLoaderMod.get_mod_data()\" instead", "6.0.0")
+	ModLoaderDeprecated.deprecated_message("The var \"mod_data\" was removed, use \"ModLoaderMod.get_mod_data_all()\" instead", "6.0.0")
 	return ModLoaderStore.mod_data


### PR DESCRIPTION
Added `get_mod_data_all()` and updated the deprecation message to point to `ModLoaderMod.get_mod_data_all()` instead of `ModLoaderMod.get_mod_data()`.