### PR TITLE
fix: always use warnings for deprecations in standalone builds

### DIFF
--- a/addons/mod_loader/api/deprecated.gd
+++ b/addons/mod_loader/api/deprecated.gd
@@ -37,7 +37,7 @@ static func deprecated_message(msg: String, since_version: String = "") -> void:
 # Internal func for logging with support to trigger warnings instead of fatal
 # errors
 static func _deprecated_log(msg: String) -> void:
-	if ModLoaderStore.ml_options.ignore_deprecated_errors:
+	if ModLoaderStore.ml_options.ignore_deprecated_errors or OS.has_feature("standalone"):
 		ModLoaderLog.warning(msg, LOG_NAME)
 	else:
 		ModLoaderLog.fatal(msg, LOG_NAME)


### PR DESCRIPTION
There seems to be an issue where deprecations can cause mods to stop working even through the `assert` from `log-fatal` should be removed. 
To circumvent this, turn all deprecations into warnings for standalone (non-editor) builds