### PR TITLE
fix: Transitive Comparator for script sorting 

### DIFF
--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -50,12 +50,14 @@ class InheritanceSorting:
 		while parent_script:
 			a_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
+		a_stack.pop_back()
 		
 		var b_stack := []
 		parent_script = load(extension_b.extension_path)
 		while parent_script:
 			b_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
+		b_stack.pop_back()
 		
 		var last_index: int
 		for index in a_stack.size():

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -54,13 +54,13 @@ class InheritanceSorting:
 		var a_stack = []
 		var parent_script = load(extension_a.extension_path)
 		while parent_script:
-			a_stack.push_back(parent_script.resource_path)
+			a_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
 		
 		var b_stack = []
 		parent_script = load(extension_b.extension_path)
 		while parent_script:
-			b_stack.push_back(parent_script.resource_path)
+			b_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
 		
 		var last_index

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -49,28 +49,33 @@ static func handle_script_extensions() -> void:
 
 # Inner class so the sort function can be called by handle_script_extensions()
 class InheritanceSorting:
-	# Go up extension_a's inheritance tree to find if any parent shares the same vanilla path as extension_b
-	static func _check_inheritances(extension_a: ScriptExtensionData, extension_b: ScriptExtensionData)->bool:
-		var a_child_script: Script
-
-		if ModLoaderStore.loaded_vanilla_parents_cache.keys().has(extension_a.parent_script_path):
-			a_child_script = ResourceLoader.load(extension_a.parent_script_path)
-		else:
-			a_child_script = ResourceLoader.load(extension_a.parent_script_path)
-			ModLoaderStore.loaded_vanilla_parents_cache[extension_a.parent_script_path] = a_child_script
-
-		var a_parent_script: Script = a_child_script.get_base_script()
-
-		if a_parent_script == null:
+	
+	static func _check_inheritances(extension_a:ScriptExtensionData, extension_b:ScriptExtensionData)->bool:
+		var a_stack = []
+		var parent_script = load(extension_a.extension_path)
+		while parent_script:
+			a_stack.push_back(parent_script.resource_path)
+			parent_script = parent_script.get_base_script()
+		
+		var b_stack = []
+		parent_script = load(extension_b.extension_path)
+		while parent_script:
+			b_stack.push_back(parent_script.resource_path)
+			parent_script = parent_script.get_base_script()
+		
+		var last_index
+		for index in a_stack.size():
+			if index >= b_stack.size():
+				return false
+			if a_stack[index] != b_stack[index]:
+				return a_stack[index] < b_stack[index]
+			last_index = index
+			
+		if last_index < b_stack.size():
+			# 'a' has a shorter stack
 			return true
-
-		var a_parent_script_path = a_parent_script.resource_path
-		if a_parent_script_path == extension_b.parent_script_path:
-			return false
-
-		else:
-			return _check_inheritances(ScriptExtensionData.new(extension_a.extension_path, a_parent_script_path, extension_a.mod_id), extension_b)
-
+			
+		return extension_a.extension_path < extension_b.extension_path
 
 static func apply_extension(extension_path: String) -> Script:
 	# Check path to file exists

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -25,9 +25,6 @@ static func handle_script_extensions() -> void:
 		var parent_script: Script = child_script.get_base_script()
 		var parent_script_path: String = parent_script.resource_path
 
-		if not ModLoaderStore.loaded_vanilla_parents_cache.keys().has(parent_script_path):
-			ModLoaderStore.loaded_vanilla_parents_cache[parent_script_path] = parent_script
-
 		script_extension_data_array.push_back(
 			ScriptExtensionData.new(extension_path, parent_script_path, mod_id)
 		)
@@ -37,9 +34,6 @@ static func handle_script_extensions() -> void:
 
 	# Inheritance is more important so this called last
 	script_extension_data_array.sort_custom(InheritanceSorting, "_check_inheritances")
-
-	# This saved some bugs in the past.
-	ModLoaderStore.loaded_vanilla_parents_cache.clear()
 
 	# Load and install all extensions
 	for extension in script_extension_data_array:
@@ -51,19 +45,19 @@ static func handle_script_extensions() -> void:
 class InheritanceSorting:
 	
 	static func _check_inheritances(extension_a:ScriptExtensionData, extension_b:ScriptExtensionData)->bool:
-		var a_stack = []
-		var parent_script = load(extension_a.extension_path)
+		var a_stack := []
+		var parent_script: Script = load(extension_a.extension_path)
 		while parent_script:
 			a_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
 		
-		var b_stack = []
+		var b_stack := []
 		parent_script = load(extension_b.extension_path)
 		while parent_script:
 			b_stack.push_front(parent_script.resource_path)
 			parent_script = parent_script.get_base_script()
 		
-		var last_index
+		var last_index: int
 		for index in a_stack.size():
 			if index >= b_stack.size():
 				return false

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -53,9 +53,6 @@ var has_shown_editor_zips_warning := false
 # Things to keep to ensure they are not garbage collected (used by `save_scene`)
 var saved_objects := []
 
-# Store vanilla classes for script extension sorting
-var loaded_vanilla_parents_cache := {}
-
 # Stores all the taken over scripts for restoration
 var saved_scripts := {}
 


### PR DESCRIPTION
The current algorithm returns a random result unless a is in b's type hierarchy.  Random results are disallowed in the sort_custom API

https://docs.godotengine.org/en/3.5/classes/class_array.html?highlight=sort_custom

The new algorithm sorts alphabetically by names in the type hierarchy paths until one of the trees stop then it sorts the shorter tree first.

Aims to fix the following errors that gets spammed at startup (and i think causes startup crashes):

E 0:00:00.815   SortArray<class Variant,struct _ArrayVariantSortCustom,1>::partitioner: bad comparison function; sorting will be broken
  <C++ Source>  .\core/sort_array.h:179 @ SortArray<class Variant,struct _ArrayVariantSortCustom,1>::partitioner()
  <Stack Trace> script_extension.gd:39 @ handle_script_extensions()
                mod_loader.gd:164 @ _load_mods()
                mod_loader.gd:67 @ _init()