### PR TITLE
refactor: ♻️ reworked mod uninstall detection

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -126,6 +126,30 @@ static func get_file_paths_in_dir(src_dir_path: String) -> Array:
 	return file_paths
 
 
+# Returns an array of directory paths inside the src dir
+static func get_dir_paths_in_dir(src_dir_path: String) -> Array:
+	var dir_paths := []
+
+	var directory := Directory.new()
+	var error := directory.open(src_dir_path)
+
+	if not error  == OK:
+		return dir_paths
+		ModLoaderLog.error("Error opening directory", LOG_NAME)
+
+	directory.list_dir_begin()
+	var file_name := directory.get_next()
+	while (file_name != ""):
+		if file_name == "." or file_name == "..":
+			file_name = directory.get_next()
+			continue
+		if directory.current_is_dir():
+			dir_paths.push_back(src_dir_path.plus_file(file_name))
+		file_name = directory.get_next()
+
+	return dir_paths
+
+
 # Get the path to the mods folder, with any applicable overrides applied
 static func get_path_to_mods() -> String:
 	var mods_folder_path := get_local_folder_dir("mods")

--- a/addons/mod_loader/internal/third_party/steam.gd
+++ b/addons/mod_loader/internal/third_party/steam.gd
@@ -9,8 +9,8 @@ const LOG_NAME := "ModLoader:ThirdParty:Steam"
 # Load mod ZIPs from Steam workshop folders. Uses 2 loops: One for each
 # workshop item's folder, with another inside that which loops over the ZIPs
 # inside each workshop item's folder
-static func load_steam_workshop_zips() -> int:
-	var temp_zipped_mods_count := 0
+static func load_steam_workshop_zips() -> Dictionary:
+	var zip_data := {}
 	var workshop_folder_path := _get_path_to_workshop()
 
 	ModLoaderLog.info("Checking workshop items, with path: \"%s\"" % workshop_folder_path, LOG_NAME)
@@ -19,11 +19,11 @@ static func load_steam_workshop_zips() -> int:
 	var workshop_dir_open_error := workshop_dir.open(workshop_folder_path)
 	if not workshop_dir_open_error == OK:
 		ModLoaderLog.error("Can't open workshop folder %s (Error: %s)" % [workshop_folder_path, workshop_dir_open_error], LOG_NAME)
-		return -1
+		return {}
 	var workshop_dir_listdir_error := workshop_dir.list_dir_begin()
 	if not workshop_dir_listdir_error == OK:
 		ModLoaderLog.error("Can't read workshop folder %s (Error: %s)" % [workshop_folder_path, workshop_dir_listdir_error], LOG_NAME)
-		return -1
+		return {}
 
 	# Loop 1: Workshop folders
 	while true:
@@ -42,11 +42,11 @@ static func load_steam_workshop_zips() -> int:
 			continue
 
 		# Loop 2: ZIPs inside the workshop folders
-		temp_zipped_mods_count += _ModLoaderFile.load_zips_in_folder(ProjectSettings.globalize_path(item_path))
+		zip_data.merge(_ModLoaderFile.load_zips_in_folder(ProjectSettings.globalize_path(item_path)))
 
 	workshop_dir.list_dir_end()
 
-	return temp_zipped_mods_count
+	return zip_data
 
 
 # Get the path to the Steam workshop folder. Only works for Steam games, as it

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -87,11 +87,20 @@ func _exit_tree() -> void:
 func _load_mods() -> void:
 	# Loop over "res://mods" and add any mod zips to the unpacked virtual
 	# directory (UNPACKED_DIR)
-	var unzipped_mods := _load_mod_zips()
-	if unzipped_mods > 0:
-		ModLoaderLog.success("DONE: Loaded %s mod files into the virtual filesystem" % unzipped_mods, LOG_NAME)
-	else:
+	var zip_data := _load_mod_zips()
+
+	if zip_data.empty():
 		ModLoaderLog.info("No zipped mods found", LOG_NAME)
+	else:
+		ModLoaderLog.success("DONE: Loaded %s mod files into the virtual filesystem" % zip_data.size(), LOG_NAME)
+
+	# Initializes the mod_data dictionary if zipped mods are loaded.
+	# If mods are unpacked in the "mods-unpacked" directory,
+	# mod_data is initialized in the _setup_mods() function.
+	for mod_id in zip_data.keys():
+		var zip_path: String = zip_data[mod_id]
+		_init_mod_data(mod_id, zip_path)
+
 
 	# Loop over UNPACKED_DIR. This triggers _init_mod_data for each mod
 	# directory, which adds their data to mod_data.
@@ -213,19 +222,21 @@ func _check_autoload_positions() -> void:
 
 # Loop over "res://mods" and add any mod zips to the unpacked virtual directory
 # (UNPACKED_DIR)
-func _load_mod_zips() -> int:
-	var zipped_mods_count := 0
+func _load_mod_zips() -> Dictionary:
+	var zip_data := {}
 
 	if not ModLoaderStore.ml_options.steam_workshop_enabled:
 		var mods_folder_path := _ModLoaderPath.get_path_to_mods()
 
 		# If we're not using Steam workshop, just loop over the mod ZIPs.
-		zipped_mods_count += _ModLoaderFile.load_zips_in_folder(mods_folder_path)
+		var loaded_zip_data := _ModLoaderFile.load_zips_in_folder(mods_folder_path)
+		zip_data.merge(loaded_zip_data)
 	else:
 		# If we're using Steam workshop, loop over the workshop item directories
-		zipped_mods_count += _ModLoaderSteam.load_steam_workshop_zips()
+		var loaded_workshop_zip_data := _ModLoaderSteam.load_steam_workshop_zips()
+		zip_data.merge(loaded_workshop_zip_data)
 
-	return zipped_mods_count
+	return zip_data
 
 
 # Loop over UNPACKED_DIR and triggers `_init_mod_data` for each mod directory,
@@ -276,19 +287,20 @@ func _setup_mods() -> int:
 # Add a mod's data to mod_data.
 # The mod_folder_path is just the folder name that was added to UNPACKED_DIR,
 # which depends on the name used in a given mod ZIP (eg "mods-unpacked/Folder-Name")
-func _init_mod_data(mod_folder_path: String) -> void:
-	# The file name should be a valid mod id
-	var dir_name := _ModLoaderPath.get_file_name_from_path(mod_folder_path, false, true)
+func _init_mod_data(mod_id: String, zip_path := "") -> void:
+		# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
+	var local_mod_path := _ModLoaderPath.get_unpacked_mods_dir_path().plus_file(mod_id)
 
-	# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
-	var local_mod_path := _ModLoaderPath.get_unpacked_mods_dir_path().plus_file(dir_name)
-
-	var mod := ModData.new(local_mod_path)
-	mod.dir_name = dir_name
+	var mod := ModData.new()
+	if not zip_path.empty():
+		mod.zip_name = _ModLoaderPath.get_file_name_from_path(zip_path)
+		mod.zip_path = zip_path
+	mod.dir_path = local_mod_path
+	mod.dir_name = mod_id
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
 	mod.is_overwrite = _ModLoaderFile.file_exists(mod_overwrites_path)
-	mod.is_locked = true if dir_name in ModLoaderStore.ml_options.locked_mods else false
-	ModLoaderStore.mod_data[dir_name] = mod
+	mod.is_locked = true if mod_id in ModLoaderStore.ml_options.locked_mods else false
+	ModLoaderStore.mod_data[mod_id] = mod
 
 	# Get the mod file paths
 	# Note: This was needed in the original version of this script, but it's

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -44,6 +44,9 @@ var mod_missing_dependencies := {}
 # Helps to decide whether a script extension should go through the _ModLoaderScriptExtension.handle_script_extensions() process
 var is_initializing := true
 
+# Used when loading mod zips to determine which mod zip corresponds to which mod directory in the UNPACKED_DIR.
+var previous_mod_dirs := []
+
 # Store all extenders paths
 var script_extensions := []
 

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -23,6 +23,10 @@ enum optional_mod_files {
 	OVERWRITES
 }
 
+# Name of the Mod's zip file
+var zip_name := ""
+# Path to the Mod's zip file
+var zip_path := ""
 # Directory of the mod. Has to be identical to [method ModManifest.get_mod_id]
 var dir_name := ""
 # Path to the Mod's Directory
@@ -43,10 +47,6 @@ var current_config: ModConfig setget _set_current_config
 
 # only set if DEBUG_ENABLE_STORING_FILEPATHS is enabled
 var file_paths: PoolStringArray = []
-
-
-func _init(_dir_path: String) -> void:
-	dir_path = _dir_path
 
 
 # Load meta data from a mod's manifest.json file


### PR DESCRIPTION
- Added `zip_name` and `zip_path` to `ModData`
- The functions responsible for loading zip files now return a dictionary containing the zip data:
```gdscript
zip_data = {
"mod_id": "path/to/zip/file.zip"
}
```
- New util `ModLoaderPath.get_dir_paths_in_dir()`
*Used in `load_zips_in_folder()` to map the zip file path to the correct mod.*
- User Profiles now store the path to the zip file associated with each mod
- Issue #288 has been resolved by implementing a check to verify the existence of the mod's zip file. 
*c587953b3bde8584e95ca85f50aa5918a9fc7aa6 Note: This allows to verify if the mod is still installed by confirming the existence of the zip file. However, this check is only performed when the mod is not loaded and a path to the zip file exists. This ensures that mods are not deleted from the profile when running in the editor. It's important to note that this new check may cause mods to appear in user profiles even if they are currently not loaded. To determine if a mod is actually loaded, you should also check `ModLoaderStore.mod_data` or use `ModLoaderMod.is_mod_loaded()`.*

depends on #297 
closes https://github.com/GodotModding/godot-mod-loader/issues/288
