### PR TITLE
fix: :bug: Fix ModLoaderUtils log deprecation using `ModLoader.*`

### DIFF
--- a/addons/mod_loader/internal/mod_loader_utils.gd
+++ b/addons/mod_loader/internal/mod_loader_utils.gd
@@ -126,47 +126,47 @@ static func get_string_in_between(string: String, initial: String, ending: Strin
 # Stops the execution in editor
 # Always logged
 static func log_fatal(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_fatal", "ModLoaderLog.fatal", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_fatal", "ModLoaderLog.fatal", "6.0.0")
 	ModLoaderLog.fatal(message, mod_name)
 
 
 # Logs the message and pushed an error. Prefixed ERROR
 # Always logged
 static func log_error(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_error", "ModLoaderLog.error", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_error", "ModLoaderLog.error", "6.0.0")
 	ModLoaderLog.error(message, mod_name)
 
 
 # Logs the message and pushes a warning. Prefixed WARNING
 # Logged with verbosity level at or above warning (-v)
 static func log_warning(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_warning", "ModLoaderLog.warning", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_warning", "ModLoaderLog.warning", "6.0.0")
 	ModLoaderLog.warning(message, mod_name)
 
 
 # Logs the message. Prefixed INFO
 # Logged with verbosity level at or above info (-vv)
 static func log_info(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_info", "ModLoaderLog.info", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_info", "ModLoaderLog.info", "6.0.0")
 	ModLoaderLog.info(message, mod_name)
 
 
 # Logs the message. Prefixed SUCCESS
 # Logged with verbosity level at or above info (-vv)
 static func log_success(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_success", "ModLoaderLog.success", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_success", "ModLoaderLog.success", "6.0.0")
 	ModLoaderLog.success(message, mod_name)
 
 
 # Logs the message. Prefixed DEBUG
 # Logged with verbosity level at or above debug (-vvv)
 static func log_debug(message: String, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_debug", "ModLoaderLog.debug", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_debug", "ModLoaderLog.debug", "6.0.0")
 	ModLoaderLog.debug(message, mod_name)
 
 
 # Logs the message formatted with [method JSON.print]. Prefixed DEBUG
 # Logged with verbosity level at or above debug (-vvv)
 static func log_debug_json_print(message: String, json_printable, mod_name: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.log_debug_json_print", "ModLoaderLog.debug_json_print", "6.0.0")
+	ModLoaderDeprecated.deprecated_changed("ModLoaderUtils.log_debug_json_print", "ModLoaderLog.debug_json_print", "6.0.0")
 	ModLoaderLog.debug_json_print(message, json_printable, mod_name)


### PR DESCRIPTION
ModLoaderUtils log deprecation messages all state the old method class was `ModLoader.*`, but this should be `ModLoaderUtils.*`. This fixes that.

Closes #299.