### PR TITLE
fix: :bug: `ModData` init and uninstall detection

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -253,17 +253,8 @@ static func _update_mod_list(mod_list: Dictionary, mod_data := ModLoaderStore.mo
 	var updated_mod_list := mod_list.duplicate(true)
 
 	# Iterate over each mod ID in the mod list
-	for mod_id in updated_mod_list:
+	for mod_id in updated_mod_list.keys():
 		var mod_list_entry: Dictionary = updated_mod_list[mod_id]
-
-		# If mod data is accessible and the mod is not loaded
-		if not mod_data.empty() and not mod_data.has(mod_id):
-			# Check if the mod_dir for the mod-id exists
-			if not _ModLoaderFile.dir_exists(_ModLoaderPath.get_unpacked_mods_dir_path() + mod_id):
-				# If the mod directory doesn't exist,
-				# the mod is no longer installed and can be removed from the mod list
-				updated_mod_list.erase(mod_id)
-				continue
 
 		# Check if the current config doesn't exist
 		# This can happen if the config file was manually deleted
@@ -271,27 +262,27 @@ static func _update_mod_list(mod_list: Dictionary, mod_data := ModLoaderStore.mo
 			# If the current config doesn't exist, reset it to the default configuration
 			mod_list_entry.current_config = ModLoaderConfig.DEFAULT_CONFIG_NAME
 
-		# If the mod is not loaded
-		if not mod_data.has(mod_id):
-			if (
-				# Check if the entry has a zip_path key
-				mod_list_entry.has("zip_path") and
-				# Check if the entry has a zip_path
-				not mod_list_entry.zip_path.empty() and
-				# Check if the zip file for the mod exists
-				not _ModLoaderFile.file_exists(mod_list_entry.zip_path)
-			):
-				# If the mod directory doesn't exist,
-				# the mod is no longer installed and can be removed from the mod list
-				ModLoaderLog.debug(
-					"Mod \"%s\" has been deleted from all user profiles as the corresponding zip file no longer exists at path \"%s\"."
-					% [mod_id, mod_list_entry.zip_path],
-					LOG_NAME,
-					true
-				)
+		if (
+			# If the mod is not loaded
+			not mod_data.has(mod_id) and
+			# Check if the entry has a zip_path key
+			mod_list_entry.has("zip_path") and
+			# Check if the entry has a zip_path
+			not mod_list_entry.zip_path.empty() and
+			# Check if the zip file for the mod doesn't exist
+			not _ModLoaderFile.file_exists(mod_list_entry.zip_path)
+		):
+			# If the mod directory doesn't exist,
+			# the mod is no longer installed and can be removed from the mod list
+			ModLoaderLog.debug(
+				"Mod \"%s\" has been deleted from all user profiles as the corresponding zip file no longer exists at path \"%s\"."
+				% [mod_id, mod_list_entry.zip_path],
+				LOG_NAME,
+				true
+			)
 
-				updated_mod_list.erase(mod_id)
-				continue
+			updated_mod_list.erase(mod_id)
+			continue
 
 		updated_mod_list[mod_id] = mod_list_entry
 

--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -58,8 +58,6 @@ static func load_zips_in_folder(folder_path: String) -> Dictionary:
 		ModLoaderLog.error("Can't read mod folder %s (Error: %s)" % [folder_path, mod_dir_listdir_error], LOG_NAME)
 		return {}
 
-
-
 	# Get all zip folders inside the game mod folder
 	while true:
 		# Get the next file in the directory

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -282,8 +282,10 @@ func _setup_mods() -> int:
 			ModLoaderLog.info("Skipped setting up mod: \"%s\"" % mod_dir_name, LOG_NAME)
 			continue
 
-		# Init the mod data for each mod
-		_init_mod_data(mod_dir_name)
+		# Initialize the mod data for each mod if there is no existing mod data for that mod.
+		if not ModLoaderStore.mod_data.has(mod_dir_name):
+			_init_mod_data(mod_dir_name)
+
 		unpacked_mods_count += 1
 
 	dir.list_dir_end()


### PR DESCRIPTION
Refactored `_update_mod_list()` by adding the missing `.keys()` call, removing the outdated check for uninstalled mods, and implemented an if statement in `_setup_mods()` within *mod_loader.gd* to prevent initializing `mod_data` twice, which resolves the issue of the missing `zip_data`.

closes #306