### PR TITLE
refactor: :recycle: unique ids `optional_dependencies` - `dependencies`

### DIFF
--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -113,6 +113,12 @@ func _init(manifest: Dictionary) -> void:
 		not validate_distinct_mod_ids_in_arrays(
 			mod_id,
 			optional_dependencies,
+			dependencies,
+			["optional_dependencies", "dependencies"]
+		) or
+		not validate_distinct_mod_ids_in_arrays(
+			mod_id,
+			optional_dependencies,
 			incompatibilities,
 			["optional_dependencies", "incompatibilities"]
 		) or


### PR DESCRIPTION
Added validation to check for the same mod_ids in `optional_dependencies` and `dependencies`

**Breaking Changes:**
Technically, it may break mods that have the same `mod_id` listed in both the `optional_dependencies` and `dependencies` sections. However, since the `optional_dependencies` feature was introduced in v6.0.0, it is highly unlikely that such conflicts exist.