### PR TITLE
refactor: :recycle: unique ids `load_before` - `incompatibilities`

### DIFF
--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -128,7 +128,13 @@ func _init(manifest: Dictionary) -> void:
 			load_before,
 			optional_dependencies,
 			["load_before", "optional_dependencies"],
-			"\"load_before\" can be viewed as optional dependency, please remove the duplicate mod-id.")
+			"\"load_before\" can be viewed as optional dependency, please remove the duplicate mod-id."
+		) or
+		not validate_distinct_mod_ids_in_arrays(
+			mod_id,
+			load_before,
+			incompatibilities,
+			["load_before", "incompatibilities"])
 	):
 		return
 


### PR DESCRIPTION
Added validation to check for the same mod_ids in `load_before` and `incompatibilities`

Breaking Changes:
Technically, it may break mods that have the same `mod_id` listed in both the `load_before` and `incompatibilities` sections. However, since the `load_before` feature was introduced in v6.0.0, it is highly unlikely that such conflicts exist.