### PR TITLE
refactor: :recycle: remove `self` argument on *mod_main.gd* init

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -336,7 +336,7 @@ func _init_mod(mod: ModData) -> void:
 	var mod_main_script := ResourceLoader.load(mod_main_path)
 	ModLoaderLog.debug("Loaded script -> %s" % mod_main_script, LOG_NAME)
 
-	var mod_main_instance: Node = mod_main_script.new(self)
+	var mod_main_instance: Node = mod_main_script.new()
 	mod_main_instance.name = mod.manifest.get_mod_id()
 
 	ModLoaderStore.saved_mod_mains[mod_main_path] = mod_main_instance


### PR DESCRIPTION
The `ModLoader` Instance is no longer required to be passed as an argument to the `mod_main.gd` `_init()` function. All methods required for mod development have been moved outside of `ModLoader`.

*Note: It seems to be non-breaking for mods that still have the parameter in their `_init()` function.*

blocked by #322
closes #318
