### PR TITLE
ci: :recycle: no longer ignore the main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,4 @@
-on:
-  pull_request:
-    branches-ignore:    
-       - 'main'
+on: [pull_request]
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- No longer prevent the `check_dependencies` task from running for release PRs.