### PR TITLE
refactor: :recycle: demote log messages

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -391,7 +391,7 @@ static func _create_new_profile(profile_name: String, mod_list: Dictionary) -> M
 
 	# If no mods are specified in the mod_list, log a warning and return the new profile
 	if mod_list.keys().size() == 0:
-		ModLoaderLog.warning("No mod_ids inside \"mod_list\" for user profile \"%s\" " % profile_name, LOG_NAME)
+		ModLoaderLog.info("No mod_ids inside \"mod_list\" for user profile \"%s\" " % profile_name, LOG_NAME)
 		return new_profile
 
 	# Set the mod_list

--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -51,7 +51,7 @@ static func load_zips_in_folder(folder_path: String) -> Dictionary:
 	var mod_dir := Directory.new()
 	var mod_dir_open_error := mod_dir.open(folder_path)
 	if not mod_dir_open_error == OK:
-		ModLoaderLog.error("Can't open mod folder %s (Error: %s)" % [folder_path, mod_dir_open_error], LOG_NAME)
+		ModLoaderLog.info("Can't open mod folder %s (Error: %s)" % [folder_path, mod_dir_open_error], LOG_NAME)
 		return {}
 	var mod_dir_listdir_error := mod_dir.list_dir_begin()
 	if not mod_dir_listdir_error == OK:


### PR DESCRIPTION
Demote the log message in `ModLoaderUserProfile` regarding "no `mod_ids` inside `mod_list`" from a warning to an info level. Similarly, demote the log message in `_ModLoaderFile` about "can't open mod folder" from an error to an info level. This adjustment is aimed at preventing confusion after the mod loader is running for the first time without any mods.

closes #327