### PR TITLE
fix: 🐛 fixed `get_global_class_list`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -23,7 +23,6 @@ const LOG_NAME := "ModLoader:Mod"
 #
 # Returns: void
 static func install_script_extension(child_script_path: String) -> void:
-
 	var mod_id: String = ModLoaderUtils.get_string_in_between(child_script_path, "res://mods-unpacked/", "/")
 	var mod_data: ModData = get_mod_data(mod_id)
 	if not ModLoaderStore.saved_extension_paths.has(mod_data.manifest.get_mod_id()):

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -123,7 +123,7 @@ static func _reload_vanilla_child_classes_for(script: Script) -> void:
 		return
 	var current_child_classes := []
 	var actual_path: String = script.get_base_script().resource_path
-	var classes: Array = ProjectSettings.get_setting("_global_script_classes")
+	var classes: Array = ProjectSettings.get_global_class_list()
 
 	for _class in classes:
 		if _class.path == actual_path:


### PR DESCRIPTION
`ProjectSettings.get_setting("_global_script_classes")` is now `ProjectSettings.get_global_class_list()`