### PR TITLE
refactor: moving time methods to ModLoaderTime

### DIFF
--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -446,22 +446,21 @@ class ModLoaderLogCompare:
 # Internal Date Time
 # =============================================================================
 
-# Returns the current time as a string in the format hh:mm:ss
-static func _get_time_string() -> String:
-	var date_time := Time.get_datetime_dict_from_system()
-	return "%02d:%02d:%02d" % [ date_time.hour, date_time.minute, date_time.second ]
+# Import the ModLoaderTime class
+const ModLoaderTime = preload("time.gd")
 
+# This create an instance of ModLoaderTime
+var time_utils = ModLoaderTime.new()
 
-# Returns the current date as a string in the format yyyy-mm-dd
-static func _get_date_string() -> String:
-	var date_time := Time.get_datetime_dict_from_system()
-	return "%s-%02d-%02d" % [ date_time.year, date_time.month, date_time.day ]
+# ModLoaderTime instance Function
+func _ready():
+    var time_str = time_utils._get_time_string()
+    var date_str = time_utils._get_date_string()
+    var date_time_str = time_utils._get_date_time_string()
 
-
-# Returns the current date and time as a string in the format yyyy-mm-dd_hh:mm:ss
-static func _get_date_time_string() -> String:
-	return "%s_%s" % [ _get_date_string(), _get_time_string() ]
-
+    print("Time: ", time_str)
+    print("Date: ", date_str)
+    print("Date-Time: ", date_time_str)
 
 
 # Internal File

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -446,21 +446,7 @@ class ModLoaderLogCompare:
 # Internal Date Time
 # =============================================================================
 
-# Import the ModLoaderTime class
-const ModLoaderTime = preload("time.gd")
 
-# This create an instance of ModLoaderTime
-var time_utils = ModLoaderTime.new()
-
-# ModLoaderTime instance Function
-func _ready():
-    var time_str = time_utils._get_time_string()
-    var date_str = time_utils._get_date_string()
-    var date_time_str = time_utils._get_date_time_string()
-
-    print("Time: ", time_str)
-    print("Date: ", date_str)
-    print("Date-Time: ", date_time_str)
 
 
 # Internal File
@@ -504,7 +490,7 @@ static func _rotate_log_file() -> void:
 	var error := log_file.open(MOD_LOG_PATH, File.WRITE)
 	if not error == OK:
 		assert(false, "Could not open log file, error code: %s" % error)
-	log_file.store_string('%s Created log' % _get_date_string())
+	log_file.store_string('%s Created log' % ModLoaderTime.get_date_string())
 	log_file.close()
 
 

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -1,3 +1,5 @@
+# ModLoaderTime class
+# This class provides utility functions to retrieve the current time, date, and date-time in specific string formats.
 class_name ModLoaderTime
 extends Node
 
@@ -6,10 +8,12 @@ static func get_time_string() -> String:
 	var date_time := Time.get_datetime_dict_from_system()
 	return "%02d:%02d:%02d" % [ date_time.hour, date_time.minute, date_time.second ]
 
+
 # Returns the current date as a string in the format yyyy-mm-dd
-static func _get_date_string() -> String:
+static func get_date_string() -> String:
 	var date_time := Time.get_datetime_dict_from_system()
 	return "%s-%02d-%02d" % [ date_time.year, date_time.month, date_time.day ]
+
 
 # Returns the current date and time as a string in the format yyyy-mm-dd_hh:mm:ss
 static func get_date_time_string() -> String:

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -2,7 +2,7 @@ class_name ModLoaderTime
 extends Node
 
 # Returns the current time as a string in the format hh:mm:ss
-static func _get_time_string() -> String:
+static func get_time_string() -> String:
 	var date_time := Time.get_datetime_dict_from_system()
 	return "%02d:%02d:%02d" % [ date_time.hour, date_time.minute, date_time.second ]
 

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -1,4 +1,3 @@
-# ModLoaderTime class
 # This class provides utility functions to retrieve the current time, date, and date-time in specific string formats.
 class_name ModLoaderTime
 extends Node

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -1,0 +1,17 @@
+extends Node
+
+class_name ModLoaderTime
+
+# Returns the current time as a string in the format hh:mm:ss
+static func _get_time_string() -> String:
+	var date_time := Time.get_datetime_dict_from_system()
+	return "%02d:%02d:%02d" % [ date_time.hour, date_time.minute, date_time.second ]
+
+# Returns the current date as a string in the format yyyy-mm-dd
+static func _get_date_string() -> String:
+	var date_time := Time.get_datetime_dict_from_system()
+	return "%s-%02d-%02d" % [ date_time.year, date_time.month, date_time.day ]
+
+# Returns the current date and time as a string in the format yyyy-mm-dd_hh:mm:ss
+static func _get_date_time_string() -> String:
+	return "%s_%s" % [ _get_date_string(), _get_time_string() ]

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -1,6 +1,5 @@
-extends Node
-
 class_name ModLoaderTime
+extends Node
 
 # Returns the current time as a string in the format hh:mm:ss
 static func _get_time_string() -> String:

--- a/addons/mod_loader/api/time.gd
+++ b/addons/mod_loader/api/time.gd
@@ -12,5 +12,5 @@ static func _get_date_string() -> String:
 	return "%s-%02d-%02d" % [ date_time.year, date_time.month, date_time.day ]
 
 # Returns the current date and time as a string in the format yyyy-mm-dd_hh:mm:ss
-static func _get_date_time_string() -> String:
+static func get_date_time_string() -> String:
 	return "%s_%s" % [ _get_date_string(), _get_time_string() ]


### PR DESCRIPTION
# DESCRIPTION

I review and updated the new Created `GDScript` file with the name `time.gd` that hold the `ModLoaderTime` class.