### PR TITLE
feat: script extensions sorter checks load order

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -24,7 +24,7 @@ const LOG_NAME := "ModLoader:Mod"
 # Returns: void
 static func install_script_extension(child_script_path: String) -> void:
 
-	var mod_id: String = ModLoaderUtils.get_string_in_between(child_script_path, "res://mods-unpacked/", "/")
+	var mod_id: String = _ModLoaderPath.get_mod_dir(child_script_path)
 	var mod_data: ModData = get_mod_data(mod_id)
 	if not ModLoaderStore.saved_extension_paths.has(mod_data.manifest.get_mod_id()):
 		ModLoaderStore.saved_extension_paths[mod_data.manifest.get_mod_id()] = []

--- a/addons/mod_loader/internal/mod_loader_utils.gd
+++ b/addons/mod_loader/internal/mod_loader_utils.gd
@@ -100,25 +100,6 @@ static func _is_valid_global_class_dict(global_class_dict: Dictionary) -> bool:
 	return true
 
 
-# Returns the string in between two strings in a provided string
-static func get_string_in_between(string: String, initial: String, ending: String) -> String:
-	var start_index: int = string.find(initial)
-	if start_index == -1:
-		ModLoaderLog.error("Initial string not found.", LOG_NAME)
-		return ""
-
-	start_index += initial.length()
-
-	var end_index: int = string.find(ending, start_index)
-	if end_index == -1:
-		ModLoaderLog.error("Ending string not found.", LOG_NAME)
-		return ""
-
-	var found_string: String = string.substr(start_index, end_index - start_index)
-
-	return found_string
-
-
 # Deprecated
 # =============================================================================
 

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -184,7 +184,7 @@ static func get_path_to_mod_config_file(mod_id: String, config_name: String) -> 
 	return mod_config_dir.plus_file( config_name + ".json")
 
 
-# Returns the mod directory
+# Returns the mod directory name ("some-mod") from a given path (e.g. "res://mods-unpacked/some-mod/extensions/extension.gd")
 static func get_mod_dir(path: String) -> String:
 	var initial = ModLoaderStore.UNPACKED_DIR
 	var ending = "/"

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -182,3 +182,24 @@ static func get_path_to_mod_config_file(mod_id: String, config_name: String) -> 
 	var mod_config_dir := get_path_to_mod_configs_dir(mod_id)
 
 	return mod_config_dir.plus_file( config_name + ".json")
+
+
+# Returns the mod directory
+static func get_mod_dir(path: String) -> String:
+	var initial = ModLoaderStore.UNPACKED_DIR
+	var ending = "/"
+	var start_index: int = path.find(initial)
+	if start_index == -1:
+		ModLoaderLog.error("Initial string not found.", LOG_NAME)
+		return ""
+
+	start_index += initial.length()
+
+	var end_index: int = path.find(ending, start_index)
+	if end_index == -1:
+		ModLoaderLog.error("Ending string not found.", LOG_NAME)
+		return ""
+
+	var found_string: String = path.substr(start_index, end_index - start_index)
+
+	return found_string

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -45,10 +45,10 @@ class InheritanceSorting:
 				return a_stack[index] < b_stack[index]
 			last_index = index
 
-		if last_index < b_stack.size():
+		if last_index < b_stack.size() - 1:
 			return true
 
-		return extension_a < extension_b
+		return compare_mods_order(extension_a, extension_b)
 	
 	# Returns a list of scripts representing all the ancestors of the extension
 	# script with the most recent ancestor last.
@@ -68,6 +68,21 @@ class InheritanceSorting:
 		
 		stack_cache[extension_path] = stack
 		return stack
+	
+	# Secondary comparator function for resolving scripts extending the same vanilla script
+	# Will return whether a comes before b in the load order
+	func compare_mods_order(extension_a:String, extension_b:String)->bool:
+		var mod_a_id = extension_a.trim_prefix(_ModLoaderPath.get_unpacked_mods_dir_path()).get_slice("/", 0)
+		var mod_b_id = extension_b.trim_prefix(_ModLoaderPath.get_unpacked_mods_dir_path()).get_slice("/", 0)
+		
+		for mod in ModLoaderStore.mod_load_order:
+			if mod.dir_name == mod_a_id:
+				return true
+			elif mod.dir_name == mod_b_id:
+				return false
+		
+		# Should never happen
+		return extension_a < extension_b
 
 
 static func apply_extension(extension_path: String) -> Script:

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -83,8 +83,8 @@ class InheritanceSorting:
 	# Secondary comparator function for resolving scripts extending the same vanilla script
 	# Will return whether a comes before b in the load order
 	func compare_mods_order(extension_a: String, extension_b: String) -> bool:
-		var mod_a_id: String = ModLoaderUtils.get_string_in_between(extension_a, unpacked_dir, "/")
-		var mod_b_id: String = ModLoaderUtils.get_string_in_between(extension_b, unpacked_dir, "/")
+		var mod_a_id: String = _ModLoaderPath.get_mod_dir(extension_a)
+		var mod_b_id: String = _ModLoaderPath.get_mod_dir(extension_b)
 		
 		return load_order[mod_a_id] < load_order[mod_b_id]
 	

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -7,6 +7,7 @@ extends Reference
 
 const LOG_NAME := "ModLoader:ScriptExtension"
 
+
 # Sort script extensions by inheritance and apply them in order
 static func handle_script_extensions() -> void:
 	var extension_paths := []
@@ -30,11 +31,14 @@ static func handle_script_extensions() -> void:
 # a script extending script B if A is an ancestor of B.
 class InheritanceSorting:
 	var stack_cache := {}
-	var load_order_table := {}
+	# This dictionary's keys are mod_ids and it stores the corresponding position in the load_order
+	var load_order := {}
 	var unpacked_dir = _ModLoaderPath.get_unpacked_mods_dir_path()
 	
-	func _init():
+	
+	func _init() -> void:
 		_populate_load_order_table()
+	
 	
 	# Comparator function.  return true if a should go before b.  This may
 	# enforce conditions beyond the stated inheritance relationship.
@@ -55,6 +59,7 @@ class InheritanceSorting:
 
 		return compare_mods_order(extension_a, extension_b)
 	
+	
 	# Returns a list of scripts representing all the ancestors of the extension
 	# script with the most recent ancestor last.
 	#
@@ -74,19 +79,21 @@ class InheritanceSorting:
 		stack_cache[extension_path] = stack
 		return stack
 	
+	
 	# Secondary comparator function for resolving scripts extending the same vanilla script
 	# Will return whether a comes before b in the load order
-	func compare_mods_order(extension_a:String, extension_b:String)->bool:
-		var mod_a_id:String = ModLoaderUtils.get_string_in_between(extension_a, unpacked_dir, "/")
-		var mod_b_id:String = ModLoaderUtils.get_string_in_between(extension_b, unpacked_dir, "/")
+	func compare_mods_order(extension_a: String, extension_b: String) -> bool:
+		var mod_a_id: String = ModLoaderUtils.get_string_in_between(extension_a, unpacked_dir, "/")
+		var mod_b_id: String = ModLoaderUtils.get_string_in_between(extension_b, unpacked_dir, "/")
 		
-		return load_order_table[mod_a_id] < load_order_table[mod_b_id]
+		return load_order[mod_a_id] < load_order[mod_b_id]
+	
 	
 	# Populate a load order dictionary for faster access and comparison between mod ids
 	func _populate_load_order_table() -> void:
 		var mod_index := 0
 		for mod in ModLoaderStore.mod_load_order:
-			load_order_table[mod.dir_name] = mod_index
+			load_order[mod.dir_name] = mod_index
 			mod_index += 1
 
 

--- a/addons/mod_loader/internal/script_extension.gd
+++ b/addons/mod_loader/internal/script_extension.gd
@@ -137,6 +137,7 @@ static func apply_extension(extension_path: String) -> Script:
 
 	return child_script
 
+
 # Reload all children classes of the vanilla class we just extended
 # Calling reload() the children of an extended class seems to allow them to be extended
 # e.g if B is a child class of A, reloading B after apply an extender of A allows extenders of B to properly extend B, taking A's extender(s) into account


### PR DESCRIPTION
the script extensions sorter will check load order to sort extensions of the same vanilla script

inheritance is still the first way of sorting, this only sorts conflicting extensions of the same vanilla script