### PR TITLE
feat: log name wildcards

### DIFF
--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -402,7 +402,7 @@ static func _is_mod_name_ignored(mod_log_name: String) -> bool:
 	# Match a mod log name with a wildcard. ex: "ModLoader:*"
 	for ignored_mod_name in ignored_mod_names:
 		if ignored_mod_name.ends_with("*"):
-			if mod_log_name.begins_with(ignored_mod_name.replace("*", "")):
+			if mod_log_name.begins_with(ignored_mod_name.trim_suffix("*")):
 				return true
 
 	# No match

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -385,15 +385,27 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 				_write_to_log_file(log_entry.get_entry())
 
 
-static func _is_mod_name_ignored(mod_name: String) -> bool:
+static func _is_mod_name_ignored(mod_log_name: String) -> bool:
 	if not ModLoaderStore:
 		return false
 
-	var ignored_mod_names := ModLoaderStore.ml_options.ignored_mod_names_in_log as Array
+	var ignored_mod_log_names := ModLoaderStore.ml_options.ignored_mod_names_in_log as Array
 
-	if not ignored_mod_names.size() == 0:
-		if mod_name in ignored_mod_names:
-			return true
+	# No ignored mod names
+	if ignored_mod_names.size() == 0:
+		return false
+
+	# Directly match a full mod log name. ex: "ModLoader:Deprecated"
+	if mod_log_name in ignored_mod_names:
+		return true
+
+	# Match a mod log name with a wildcard. ex: "ModLoader:*"
+	for ignored_mod_name in ignored_mod_names:
+		if ignored_mod_name.ends_with("*"):
+			if mod_log_name.begins_with(ignored_mod_name.replace("*", "")):
+				return true
+
+	# No match
 	return false
 
 

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -392,15 +392,15 @@ static func _is_mod_name_ignored(mod_log_name: String) -> bool:
 	var ignored_mod_log_names := ModLoaderStore.ml_options.ignored_mod_names_in_log as Array
 
 	# No ignored mod names
-	if ignored_mod_names.size() == 0:
+	if ignored_mod_log_names.size() == 0:
 		return false
 
 	# Directly match a full mod log name. ex: "ModLoader:Deprecated"
-	if mod_log_name in ignored_mod_names:
+	if mod_log_name in ignored_mod_log_names:
 		return true
 
 	# Match a mod log name with a wildcard. ex: "ModLoader:*"
-	for ignored_mod_name in ignored_mod_names:
+	for ignored_mod_name in ignored_mod_log_names:
 		if ignored_mod_name.ends_with("*"):
 			if mod_log_name.begins_with(ignored_mod_name.trim_suffix("*")):
 				return true

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -24,7 +24,7 @@ signal logged(entry)
 signal current_config_changed(config)
 
 # Prefix for this file when using mod_log or dev_log
-const LOG_NAME := "ModLoader"
+const LOG_NAME := "ModLoader:Loader"
 
 # --- DEPRECATED ---
 # UNPACKED_DIR was moved to ModLoaderStore.


### PR DESCRIPTION
Before, it was only possible to match 100% of a log name to ignore it e.g. `ModLoader:Deprecated`. This can get tedious if you want to ignore all logs from a log name. 
Now you can use a wildcard at the end e.g. `ModLoader:*` to ignore all log names starting with that segment.

Resubmission of #331, since it got lost between branch resets somehow
- #331 

