### PR TITLE
fix: config MD5 check

### DIFF
--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -227,7 +227,7 @@ func load_mod_config_defaults() -> ModConfig:
 		var cache_schema_md5: String = cache_schema_md5s[config.mod_id] if cache_schema_md5s.has(config.mod_id) else ''
 
 		# Generate a new default config if the config schema has changed or there is nothing cached
-		if not current_schema_md5 == cache_schema_md5 or not cache_schema_md5.is_empty():
+		if current_schema_md5 != cache_schema_md5 or cache_schema_md5.is_empty():
 			config.data = _generate_default_config_from_schema(config.schema.properties)
 
 		# If the config schema has not changed just load the json file

--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -227,7 +227,7 @@ func load_mod_config_defaults() -> ModConfig:
 		var cache_schema_md5: String = cache_schema_md5s[config.mod_id] if cache_schema_md5s.has(config.mod_id) else ''
 
 		# Generate a new default config if the config schema has changed or there is nothing cached
-		if current_schema_md5 != cache_schema_md5 or cache_schema_md5.is_empty():
+		if not current_schema_md5 == cache_schema_md5 or cache_schema_md5.is_empty():
 			config.data = _generate_default_config_from_schema(config.schema.properties)
 
 		# If the config schema has not changed just load the json file


### PR DESCRIPTION
the condition here was incorrect, causing configs to always get overwritten on startup, this commit fixes the issue, the comment above confirms that this was the intended condition too