### PR TITLE
feat: :sparkles: adds `refresh_scene` and `extend_scene`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -95,7 +95,7 @@ static func refresh_scene(scene_path: String) -> void:
 
 
 # Extends a specific scene by providing a callable function to modify it.
-# The callable recives an instance of the vanilla_scene as the first parameter.
+# The callable receives an instance of the vanilla_scene as the first parameter.
 #
 # Parameters:
 # - scene_vanilla_path (String): The path to the vanilla scene file.

--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -160,14 +160,3 @@ static func is_mod_loaded(mod_id: String) -> bool:
 		return false
 
 	return true
-
-
-# Deprecated
-# =============================================================================
-
-func append_node_in_scene(modified_scene: Node, node_name: String = "", node_parent = null, instance_path: String = "", is_visible: bool = true) -> void:
-	ModLoaderDeprecated.deprecated_message("ModLoaderMod.append_node_in_scene has been removed, use ModLoaderMod.extend_scene() to edit non preloaded scenes.", "7.0.0")
-
-
-func save_scene(modified_scene: Node, scene_path: String) -> void:
-	ModLoaderDeprecated.deprecated_message("ModLoaderMod.save_scene has been removed, use ModLoaderMod.extend_scene() to edit non preloaded scenes.", "7.0.0")

--- a/addons/mod_loader/internal/scene_extension.gd
+++ b/addons/mod_loader/internal/scene_extension.gd
@@ -1,0 +1,43 @@
+class_name _ModLoaderSceneExtension
+extends RefCounted
+
+# This Class provides methods for working with scene extensions.
+# Currently all of the included methods are internal and should only be used by the mod loader itself.
+
+const LOG_NAME := "ModLoader:SceneExtension"
+
+
+# Iterates over the list of scenes to refresh them from storage.
+# Used to apply script extensions to preloaded scenes.
+static func refresh_scenes() -> void:
+	for scene_path in ModLoaderStore.scenes_to_refresh:
+		# Refresh cached scenes from storage
+		var _scene_from_file: PackedScene = ResourceLoader.load(scene_path, "", ResourceLoader.CACHE_MODE_REPLACE)
+		ModLoaderLog.debug("Refreshed scene at path: %s" % scene_path, LOG_NAME)
+
+
+# Iterates over the list of scenes to modify and applies the specified edits to each scene.
+static func handle_scene_extensions() -> void:
+	for scene_path in ModLoaderStore.scenes_to_modify.keys():
+		for edit_callable in ModLoaderStore.scenes_to_modify[scene_path]:
+			var cached_scene: PackedScene = load(scene_path)
+			var cached_scene_instance: Node = cached_scene.instantiate()
+			var edited_scene: Node = edit_callable.call(cached_scene_instance)
+			_save_scene(edited_scene, scene_path)
+
+
+# Saves a modified scene to resource cache.
+# Further attempts to load this scene by path will instead return this resource.
+#
+# Parameters:
+# - modified_scene (Node): The modified scene instance to be saved.
+# - scene_path (String): The path to the scene file that will be replaced.
+#
+# Returns: void
+static func _save_scene(modified_scene: Node, scene_path: String) -> void:
+	var packed_scene := PackedScene.new()
+	var _pack_error := packed_scene.pack(modified_scene)
+	ModLoaderLog.debug("packing scene -> %s" % packed_scene, LOG_NAME)
+	packed_scene.take_over_path(scene_path)
+	ModLoaderLog.debug("save_scene - taking over path - new path -> %s" % packed_scene.resource_path, LOG_NAME)
+	ModLoaderStore.saved_objects.append(packed_scene)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -184,6 +184,8 @@ func _load_mods() -> void:
 
 	_ModLoaderSceneExtension.handle_scene_extensions()
 
+	ModLoaderLog.success("DONE: Applied all scene extensions", LOG_NAME)
+
 	ModLoaderStore.is_initializing = false
 
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -180,6 +180,10 @@ func _load_mods() -> void:
 
 	ModLoaderLog.success("DONE: Installed all script extensions", LOG_NAME)
 
+	_ModLoaderSceneExtension.refresh_scenes()
+
+	_ModLoaderSceneExtension.handle_scene_extensions()
+
 	ModLoaderStore.is_initializing = false
 
 
@@ -235,7 +239,7 @@ func _load_mod_zips() -> Dictionary:
 		# Loop over the mod zips in the "mods" directory
 		var loaded_zip_data := _ModLoaderFile.load_zips_in_folder(mods_folder_path)
 		zip_data.merge(loaded_zip_data)
-	
+
 	if ModLoaderStore.ml_options.load_from_steam_workshop or ModLoaderStore.ml_options.steam_workshop_enabled:
 		# If we're using Steam workshop, loop over the workshop item directories
 		var loaded_workshop_zip_data := _ModLoaderSteam.load_steam_workshop_zips()
@@ -396,16 +400,6 @@ func register_global_classes_from_array(new_global_classes: Array) -> void:
 func add_translation_from_resource(resource_path: String) -> void:
 	ModLoaderDeprecated.deprecated_changed("ModLoader.add_translation_from_resource", "ModLoaderMod.add_translation", "6.0.0")
 	ModLoaderMod.add_translation(resource_path)
-
-
-func append_node_in_scene(modified_scene: Node, node_name: String = "", node_parent = null, instance_path: String = "", is_visible: bool = true) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.append_node_in_scene", "ModLoaderMod.append_node_in_scene", "6.0.0")
-	ModLoaderMod.append_node_in_scene(modified_scene, node_name, node_parent, instance_path, is_visible)
-
-
-func save_scene(modified_scene: Node, scene_path: String) -> void:
-	ModLoaderDeprecated.deprecated_changed("ModLoader.save_scene", "ModLoaderMod.save_scene", "6.0.0")
-	ModLoaderMod.save_scene(modified_scene, scene_path)
 
 
 func get_mod_config(mod_dir_name: String = "", key: String = "") -> ModConfig:

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -50,6 +50,13 @@ var previous_mod_dirs := []
 # Store all extenders paths
 var script_extensions := []
 
+# Stores scene paths that need to be reloaded from file.
+# Used to apply extension to scripts that are attached to preloaded scenes.
+var scenes_to_refresh := []
+
+# Stores edited version of vanilla PackedScenes, this version are applied after possible refresh of the scene.
+var scenes_to_modify := {}
+
 # True if ModLoader has displayed the warning about using zipped mods
 var has_shown_editor_zips_warning := false
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -54,7 +54,8 @@ var script_extensions := []
 # Used to apply extension to scripts that are attached to preloaded scenes.
 var scenes_to_refresh := []
 
-# Stores edited version of vanilla PackedScenes, this version are applied after possible refresh of the scene.
+# Dictionary of callables to modify a specific scene.
+# Example property: "scene_path": [Callable, Callable]
 var scenes_to_modify := {}
 
 # True if ModLoader has displayed the warning about using zipped mods


### PR DESCRIPTION
## Changes to ModLoaderMod

### New Methods

**`static func refresh_scene(scene_path: String) -> void:`**
Refreshes a specific scene by marking it for refresh.

This function is useful if a script extension is not automatically applied. This situation can occur when a script is attached to a preloaded scene. If you encounter issues where your script extension is not working as expected, try to identify the scene to which it is attached and use this method to refresh it. This will reload already loaded scenes and apply the script extension.

🚨 `refresh_scene` will only work for Godot 4.3 and up. 🚨

**`static func extend_scene(scene_vanilla_path: String, edit_callable: Callable) -> void:`**
Extends a specific scene by providing a callable function to modify it. The callable receives an instance of the vanilla_scene as the first parameter.

### Removed Methods

**`static func append_node_in_scene(modified_scene: Node, node_name: String = "", node_parent = null, instance_path: String = "", is_visible: bool = true) -> void:`**
Removed without replacement because it was always unintuitive to use. Instead of this method, the scene extension setup can be used to add a node to a scene.

**`static func save_scene(modified_scene: Node, scene_path: String) -> void:`**
`save_scene` has been moved to *scene_extension.gd* as an internal method used by `handle_scene_extensions()`

## New Class - `_ModLoaderSceneExtension`

Similar to `_ModLoaderScriptExtension`, this class encompasses everything related to modifying PackedScenes, with the hope of continuous improvement.

Currently, preloaded scenes can't be modified using these methods because `CACHE_MODE_REPLACE` loads the scene from file and, with that, wipes any changes stored in the cached instance. For loaded scenes, this should work just fine.

*💡 Preloaded scenes can be modified by adding the code to the script extension.*

## Changes to ModLoader

- Removed deprecation of `append_node_in_scene` and `save_scene`. I think we can remove the other deprecations in a subsequent PR.
- Added calls to `_ModLoaderSceneExtension.refresh_scenes()` and `_ModLoaderSceneExtension.handle_scene_extensions()` at the end of `_load_mods()`

## Changes to ModLoaderStore

- Added `var scenes_to_refresh := []` 
Stores scene paths that need to be reloaded from file.
- Added `var scenes_to_modify := {}` 
Dictionary of callables to modify a specific scene. 
Example property: `"scene_path": [Callable, Callable]`

## Example mod_main.gd
```gdscript
extends Node

const TEST_MOD0_DIR := "Test-Mod0"
const TEST_MOD0_LOG_NAME := "Test-Mod0:Main"

var mod_dir_path := ""
var extensions_dir_path := ""
var translations_dir_path := ""


func _init() -> void:
	mod_dir_path = ModLoaderMod.get_unpacked_dir().path_join(TEST_MOD0_DIR)
	# Add extensions
	install_script_extensions()
	# Edit Scenes
	edit_scenes()


func install_script_extensions() -> void:
	extensions_dir_path = mod_dir_path.path_join("extensions")
	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("preload_scene.gd"))
	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("main.gd"))


func edit_main_scene(scene_instance: Node) -> Node:
	var button: Button = scene_instance.get_node("CanvasLayer/Button")
	button.text = "MODDDED!!!!!"

	return scene_instance


func edit_scenes() -> void:
	ModLoaderMod.refresh_scene("res://preload_scene.tscn")
	ModLoaderMod.extend_scene("res://main.tscn", edit_main_scene)
```

Closes #377