### PR TITLE
feat: :sparkles: store the mod source in `ModData`

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -300,7 +300,7 @@ func _init_mod_data(mod_id: String, zip_path := "") -> void:
 	if not zip_path.is_empty():
 		mod.zip_name = _ModLoaderPath.get_file_name_from_path(zip_path)
 		mod.zip_path = zip_path
-		mod.set_mod_source(zip_path)
+		mod.source = mod.get_mod_source()
 	mod.dir_path = local_mod_path
 	mod.dir_name = mod_id
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -293,7 +293,7 @@ func _setup_mods() -> int:
 # The mod_folder_path is just the folder name that was added to UNPACKED_DIR,
 # which depends on the name used in a given mod ZIP (eg "mods-unpacked/Folder-Name")
 func _init_mod_data(mod_id: String, zip_path := "") -> void:
-		# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
+	# Path to the mod in UNPACKED_DIR (eg "res://mods-unpacked/My-Mod")
 	var local_mod_path := _ModLoaderPath.get_unpacked_mods_dir_path().path_join(mod_id)
 
 	var mod := ModData.new()

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -300,11 +300,13 @@ func _init_mod_data(mod_id: String, zip_path := "") -> void:
 	if not zip_path.is_empty():
 		mod.zip_name = _ModLoaderPath.get_file_name_from_path(zip_path)
 		mod.zip_path = zip_path
+		mod.set_mod_source(zip_path)
 	mod.dir_path = local_mod_path
 	mod.dir_name = mod_id
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
 	mod.is_overwrite = _ModLoaderFile.file_exists(mod_overwrites_path)
 	mod.is_locked = true if mod_id in ModLoaderStore.ml_options.locked_mods else false
+
 	ModLoaderStore.mod_data[mod_id] = mod
 
 	# Get the mod file paths

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -174,13 +174,10 @@ func get_optional_mod_file_path(optional_file: int) -> String:
 	return ""
 
 
-func set_mod_source(path: String) -> void:
-	if path.contains("workshop"):
-		source = sources.STEAM_WORKSHOP
-		return
+func get_mod_source() -> sources:
+	if zip_path.contains("workshop"):
+		return sources.STEAM_WORKSHOP
+	if zip_path == "":
+		return sources.UNPACKED
 
-	if path == "":
-		source = sources.UNPACKED
-		return
-
-	source = sources.LOCAL
+	return sources.LOCAL

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -23,6 +23,16 @@ enum optional_mod_files {
 	OVERWRITES
 }
 
+# Specifies the source from which the mod has been loaded:
+# UNPACKED = From the mods-unpacked directory ( only when in the editor ).
+# LOCAL = From the local mod zip directory, which by default is ../game_dir/mods.
+# STEAM_WORKSHOP = Loaded from ../Steam/steamapps/workshop/content/1234567/[..].
+enum sources {
+	UNPACKED,
+	LOCAL,
+	STEAM_WORKSHOP,
+}
+
 # Name of the Mod's zip file
 var zip_name := ""
 # Path to the Mod's zip file
@@ -47,6 +57,8 @@ var manifest: ModManifest
 # Updated in load_configs
 var configs := {}
 var current_config: ModConfig: set = _set_current_config
+# Specifies the source from which the mod has been loaded
+var source: int
 
 # only set if DEBUG_ENABLE_STORING_FILEPATHS is enabled
 var file_paths: PackedStringArray = []
@@ -154,8 +166,21 @@ func get_required_mod_file_path(required_file: int) -> String:
 			return dir_path.path_join("manifest.json")
 	return ""
 
+
 func get_optional_mod_file_path(optional_file: int) -> String:
 	match optional_file:
 		optional_mod_files.OVERWRITES:
 			return dir_path.path_join("overwrites.gd")
 	return ""
+
+
+func set_mod_source(path: String) -> void:
+	if path.contains("workshop"):
+		source = sources.STEAM_WORKSHOP
+		return
+
+	if path == "":
+		source = sources.UNPACKED
+		return
+
+	source = sources.LOCAL


### PR DESCRIPTION
- Added the `sources` enum to `ModData`. 
- Added the `get_mod_source()` function to  `ModData`. 
- Updated `_init_mod_data()` in `ModLoader` to set the mod source.