### PR TITLE
feat: :sparkles: added `steam_id` to `ml_options`

### DIFF
--- a/addons/mod_loader/internal/third_party/steam.gd
+++ b/addons/mod_loader/internal/third_party/steam.gd
@@ -77,11 +77,17 @@ static func _get_path_to_workshop() -> String:
 	return path
 
 
-# Gets the steam app ID from steam_data.json, which should be in the root
+# Gets the steam app ID from ml_options or the steam_data.json, which should be in the root
 # directory (ie. res://steam_data.json). This file is used by Godot Workshop
 # Utility (GWU), which was developed by Brotato developer Blobfish:
 # https://github.com/thomasgvd/godot-workshop-utility
 static func _get_steam_app_id() -> String:
+	# Check if the steam id is stored in the options
+	if ModLoaderStore.ml_options.steam_id:
+		return str(ModLoaderStore.ml_options.steam_id)
+		ModLoaderLog.debug("No Steam ID specified in the Mod Loader options. Attempting to read the steam_data.json file next.", LOG_NAME)
+
+	# If the steam_id is not stored in the options try to get it from the steam_data.json file.
 	var game_install_directory := _ModLoaderPath.get_local_folder_dir()
 	var steam_app_id := ""
 	var file := FileAccess.open(game_install_directory.path_join("steam_data.json"), FileAccess.READ)

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -122,6 +122,9 @@ var ml_options := {
 	# INFO: Redundant since the introduction of mod source options, kept for backwards compatibility.
 	steam_workshop_enabled = false,
 
+	# Application's Steam ID, used if workshop is enabled
+	steam_id = 0,
+
 	# Overrides for the path mods/configs/workshop folders are loaded from.
 	# Only applied if custom settings are provided, either via the options.tres
 	# resource, or via CLI args. Note that CLI args can be tested in the editor

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -11,6 +11,7 @@ extends Resource
 @export var disabled_mods: Array[String] = []
 @export var allow_modloader_autoloads_anywhere: bool = false
 @export var steam_workshop_enabled: bool = false
+@export var steam_id: int = 0
 @export_dir var override_path_to_mods = ""
 @export_dir var override_path_to_configs = ""
 @export_dir var override_path_to_workshop = ""


### PR DESCRIPTION
Allows storing the game's Steam ID in the Mod Loader Options. 
- Updated `_get_steam_app_id()` to check `ml_options` before attempting to retrieve the ID from `steam_data.json`.