### PR TITLE
feat: :sparkles: added `steam_workshop_id` to `ModManifest`

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -53,6 +53,16 @@ static func get_file_name_from_path(path: String, make_lower_case := true, remov
 	return file_name
 
 
+# Provide a zip_path to a workshop mod, returns the steam_workshop_id
+static func get_steam_workshop_id(zip_path: String) -> String:
+	var zip_path_global := ProjectSettings.globalize_path(zip_path)
+
+	if not zip_path_global.contains("/Steam/steamapps/workshop/content"):
+		return ""
+
+	return zip_path.get_base_dir().split("/")[-1]
+
+
 # Get a flat array of all files in the target directory. This was needed in the
 # original version of this script, before becoming deprecated. It may still be
 # used if DEBUG_ENABLE_STORING_FILEPATHS is true.

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -55,8 +55,6 @@ static func get_file_name_from_path(path: String, make_lower_case := true, remov
 
 # Provide a zip_path to a workshop mod, returns the steam_workshop_id
 static func get_steam_workshop_id(zip_path: String) -> String:
-	var zip_path_global := ProjectSettings.globalize_path(zip_path)
-
 	if not zip_path_global.contains("/Steam/steamapps/workshop/content"):
 		return ""
 


### PR DESCRIPTION
Added an optional field `steam_workshop_id` to `ModManifest`. 

In the editor, it is validated with a basic string length check. Once loaded from a workshop path, it's validated based on the `zip_path`. If invalid, it's overridden by the correct ID retrieved from the `zip_path`.