### PR TITLE
refactor: :recycle: Changed `disabled_mods` setting to load metadata

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -192,11 +192,11 @@ static func get_all_as_array() -> Array:
 # =============================================================================
 
 
-# Update the global list of disabled mods based on the current user profile
-# The user profile will override the disabled_mods property that can be set via the options resource in the editor.
-# Example: If "Mod-TestMod" is set in disabled_mods via the editor, the mod will appear disabled in the user profile.
-# If the user then enables the mod in the profile the entry in disabled_mods will be removed.
-static func _update_disabled_mods() -> void:
+# Update the global list of deactivated mods based on the current user profile
+# The user profile will override the deactivated_mods property that can be set via the options resource in the editor.
+# Example: If "Mod-TestMod" is set in deactivated_mods via the editor, the mod will appear deactivated in the user profile.
+# If the user then enables the mod in the profile the entry in deactivated_mods will be removed.
+static func _update_deactivated_mods() -> void:
 	var current_user_profile: ModUserProfile = get_current()
 
 	# Check if a current user profile is set
@@ -204,7 +204,7 @@ static func _update_disabled_mods() -> void:
 		ModLoaderLog.info("There is no current user profile. The \"default\" profile will be created.", LOG_NAME)
 		return
 
-	# Iterate through the mod list in the current user profile to find disabled mods
+	# Iterate through the mod list in the current user profile to find deactivated mods
 	for mod_id in current_user_profile.mod_list:
 		var mod_list_entry: Dictionary = current_user_profile.mod_list[mod_id]
 		if ModLoaderStore.mod_data.has(mod_id):
@@ -221,7 +221,7 @@ static func _update_disabled_mods() -> void:
 # Additionally, it checks for and deletes any mods from each profile's mod list that are no longer installed on the system.
 static func _update_mod_lists() -> bool:
 	# Generate a list of currently present mods by combining the mods
-	# in mod_data and ml_options.disabled_mods from ModLoaderStore.
+	# in mod_data and ml_options.deactivated_mods from ModLoaderStore.
 	var current_mod_list := _generate_mod_list()
 
 	# Iterate over all user profiles
@@ -297,7 +297,7 @@ static func _generate_mod_list() -> Dictionary:
 		mod_list[mod_id] = _generate_mod_list_entry(mod_id, true)
 
 	# Add the deactivated mods to the list
-	for mod_id in ModLoaderStore.ml_options.disabled_mods:
+	for mod_id in ModLoaderStore.ml_options.deactivated_mods:
 		mod_list[mod_id] = _generate_mod_list_entry(mod_id, false)
 
 	return mod_list
@@ -404,9 +404,9 @@ static func _load() -> bool:
 	# Load JSON data from the user profiles file
 	var data := _ModLoaderFile.get_json_as_dict(FILE_PATH_USER_PROFILES)
 
-	# If there is no data, log an error and return
+	# If there is no data, log an info and return
 	if data.is_empty():
-		ModLoaderLog.error("No profile file found at \"%s\"" % FILE_PATH_USER_PROFILES, LOG_NAME)
+		ModLoaderLog.info("No profile file found at \"%s\"" % FILE_PATH_USER_PROFILES, LOG_NAME)
 		return false
 
 	# Loop through each profile in the data and add them to ModLoaderStore

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -5,8 +5,8 @@ extends RefCounted
 # This Class provides util functions for working with paths.
 # Currently all of the included functions are internal and should only be used by the mod loader itself.
 
-const LOG_NAME := "ModLoader:Path3D"
-const MOD_CONFIG_DIR_PATH := "user://configs"
+const LOG_NAME := "ModLoader:Path"
+const MOD_CONFIG_DIR_PATH := "user://mod_configs"
 
 
 # Get the path to a local folder. Primarily used to get the  (packed) mods

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -63,11 +63,6 @@ func _init() -> void:
 
 
 func _ready():
-	# Create the default user profile if it doesn't exist already
-	# This should always be present unless the JSON file was manually edited
-	if not ModLoaderStore.user_profiles.has("default"):
-		var _success_user_profile_create := ModLoaderUserProfile.create_profile("default")
-
 	# Update the mod_list for each user profile
 	var _success_update_mod_lists := ModLoaderUserProfile._update_mod_lists()
 
@@ -104,7 +99,7 @@ func _load_mods() -> void:
 		ModLoaderLog.info("No mods were setup", LOG_NAME)
 
 	# Update active state of mods based on the current user profile
-	ModLoaderUserProfile._update_disabled_mods()
+	ModLoaderUserProfile._update_deactivated_mods()
 
 	# Loop over all loaded mods via their entry in mod_data. Verify that they
 	# have all the required files (REQUIRED_MOD_FILES), load their meta data
@@ -113,10 +108,21 @@ func _load_mods() -> void:
 	for dir_name in ModLoaderStore.mod_data:
 		var mod: ModData = ModLoaderStore.mod_data[dir_name]
 		mod.load_manifest()
+
+	ModLoaderLog.success("DONE: Loaded all meta data", LOG_NAME)
+
+	# Create the default user profile if it doesn't already exist.
+	# This should only occur on the first run of the game or if the JSON file was manually edited.
+	if not ModLoaderStore.user_profiles.has("default"):
+		var _success_user_profile_create := ModLoaderUserProfile.create_profile("default")
+
+	# Load Mod Configs
+	for dir_name in ModLoaderStore.mod_data:
+		var mod: ModData = ModLoaderStore.mod_data[dir_name]
 		if mod.manifest.get("config_schema") and not mod.manifest.config_schema.is_empty():
 			mod.load_configs()
 
-	ModLoaderLog.success("DONE: Loaded all meta data", LOG_NAME)
+	ModLoaderLog.success("DONE: Loaded all mod configs", LOG_NAME)
 
 	# Check for mods with load_before. If a mod is listed in load_before,
 	# add the current mod to the dependencies of the the mod specified
@@ -278,10 +284,6 @@ func _setup_mods() -> int:
 		):
 			continue
 
-		if ModLoaderStore.ml_options.disabled_mods.has(mod_dir_name):
-			ModLoaderLog.info("Skipped setting up mod: \"%s\"" % mod_dir_name, LOG_NAME)
-			continue
-
 		# Initialize the mod data for each mod if there is no existing mod data for that mod.
 		if not ModLoaderStore.mod_data.has(mod_dir_name):
 			_init_mod_data(mod_dir_name)
@@ -309,6 +311,7 @@ func _init_mod_data(mod_id: String, zip_path := "") -> void:
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
 	mod.is_overwrite = _ModLoaderFile.file_exists(mod_overwrites_path)
 	mod.is_locked = true if mod_id in ModLoaderStore.ml_options.locked_mods else false
+	mod.is_active = true if not ModLoaderStore.ml_options.deactivated_mods.has(mod_id) else false
 
 	ModLoaderStore.mod_data[mod_id] = mod
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -107,11 +107,11 @@ var ml_options := {
 	enable_mods = true,
 	log_level = ModLoaderLog.VERBOSITY_LEVEL.DEBUG,
 
-	# Mods that can't be disabled or enabled in a user profile (contains mod IDs as strings)
+	# Mods that can't be deactivated or enabled in a user profile (contains mod IDs as strings)
 	locked_mods = [],
 
-	# Array of disabled mods (contains mod IDs as strings)
-	disabled_mods = [],
+	# Array of deactivated mods (contains mod IDs as strings)
+	deactivated_mods = [],
 
 	# If this flag is set to true, the ModLoaderStore and ModLoader Autoloads don't have to be the first Autoloads.
 	# The ModLoaderStore Autoload still needs to be placed before the ModLoader Autoload.

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -47,7 +47,7 @@ var dir_path := ""
 var is_loadable := true
 ## True if overwrites.gd exists
 var is_overwrite := false
-## True if mod can't be disabled or enabled in a user profile
+# True if mod can't be deactivated or enabled in a user profile
 var is_locked := false
 ## Flag indicating whether the mod should be loaded
 var is_active := true
@@ -121,6 +121,10 @@ func _load_config(config_file_path: String) -> void:
 
 	# Add the config to the configs dictionary
 	configs[mod_config.name] = mod_config
+
+	# Set it as the current_config if there is none
+	if not current_config:
+		current_config = mod_config
 
 
 # Update the mod_list of the current user profile

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -5,7 +5,10 @@ extends Resource
 @export var enable_mods: bool = true
 @export var locked_mods: Array[String] = []
 @export var log_level := ModLoaderLog.VERBOSITY_LEVEL.DEBUG
-@export var disabled_mods: Array[String] = []
+## Mods in this array will only load metadata but will not apply any modifications.
+## This can be used to deactivate example mods.
+## Mods in this array are overridden by the settings in the user profile.
+@export var deactivated_mods: Array[String] = []
 @export var allow_modloader_autoloads_anywhere: bool = false
 @export var steam_id: int = 0
 @export_dir var override_path_to_mods = ""


### PR DESCRIPTION
- Renamed `disabled_mods` to `deactivated_mods`. 
- Moved default profile creation in `mod_loader.gd` from `_ready()` to `_load_mods()`. This is required so mod configs can be loaded on the first run of the game. 
- Separated loading of mod manifests and mod configs to allow the creation of the default user profile in between. 
- Demoted "No profile" error from error to info because on the first run of the game, the file will not be there. 
- Fixed the `LOG_NAME` of `_ModLoaderPath`. 
- Changed the `MOD_CONFIG_DIR_PATH` from `"user://configs"` to `"user://mod_configs"` to make it clearer what kind of configs are stored. 
- Fixed an issue where `current_config` was `null` because it wasn't set in `ModData._load_config`.