### PR TITLE
feat: :sparkles: scan zips before loading

### DIFF
--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -45,6 +45,50 @@ static func _get_json_string_as_dict(string: String) -> Dictionary:
 	return test_json_conv.data
 
 
+# Scans a zip file for disallowed content.
+# Returns true if disallowed content is found, false otherwise.
+static func scan_zip(zip_path: String) -> bool:
+	var reader := ZIPReader.new()
+	var err := reader.open(zip_path)
+	var files: PackedStringArray
+	var contains_disallowed_content := false
+
+	# Check for errors during ZIP file opening
+	if not err == OK:
+		return false
+
+	files = reader.get_files()
+
+	# Iterate through each file in the ZIP archive
+	for file in files:
+		var file_data: PackedByteArray
+		var file_string: String
+		var file_extension := file.get_extension()
+
+		# Read the content of the file if it's a script or scene file
+		if file_extension == "gd" or file_extension == "tscn":
+			file_data = reader.read_file(file)
+			file_string = file_data.get_string_from_utf8()
+
+		if file_extension == "gd":
+			# Check for disallowed script classes
+			for disallowed_script_class in ModLoaderStore.ml_options.disallowed_script_classes:
+				if file_string.contains("%s." % disallowed_script_class):
+					ModLoaderLog.warning("Script with call to \"%s\" detected!" % disallowed_script_class, LOG_NAME)
+					contains_disallowed_content = true
+
+		if file_extension == "tscn":
+			# Check for disallowed scene nodes
+			for disallowed_scene_node in ModLoaderStore.ml_options.disallowed_scene_nodes:
+				if file_string.contains(disallowed_scene_node):
+					ModLoaderLog.warning("Scene with disallowed Node \"%s\" detected!" % disallowed_scene_node, LOG_NAME)
+					contains_disallowed_content = true
+
+	reader.close()
+
+	return contains_disallowed_content
+
+
 # Load the mod ZIP from the provided directory
 static func load_zips_in_folder(folder_path: String) -> Dictionary:
 	var URL_MOD_STRUCTURE_DOCS := "https://github.com/GodotModding/godot-mod-loader/wiki/Mod-Structure"
@@ -59,7 +103,7 @@ static func load_zips_in_folder(folder_path: String) -> Dictionary:
 	if not mod_dir_open_error == OK:
 		ModLoaderLog.info("Can't open mod folder %s (Error: %s)" % [folder_path, mod_dir_open_error], LOG_NAME)
 		return {}
-	var mod_dir_listdir_error := mod_dir.list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547
+	var mod_dir_listdir_error := mod_dir.list_dir_begin()
 	if not mod_dir_listdir_error == OK:
 		ModLoaderLog.error("Can't read mod folder %s (Error: %s)" % [folder_path, mod_dir_listdir_error], LOG_NAME)
 		return {}
@@ -85,6 +129,10 @@ static func load_zips_in_folder(folder_path: String) -> Dictionary:
 
 		var mod_zip_path := folder_path.path_join(mod_zip_file_name)
 		var mod_zip_global_path := ProjectSettings.globalize_path(mod_zip_path)
+		var contains_disallowed_content := scan_zip(mod_zip_path)
+		if contains_disallowed_content:
+			ModLoaderLog.warning("disallowed mod content detected - skipped mod from path \"%s\"" % mod_zip_path, LOG_NAME)
+			continue
 		var is_mod_loaded_successfully := ProjectSettings.load_resource_pack(mod_zip_global_path, false)
 
 		# Get the current directories inside UNPACKED_DIR

--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -71,17 +71,17 @@ static func scan_zip(zip_path: String) -> bool:
 			file_string = file_data.get_string_from_utf8()
 
 		if file_extension == "gd":
-			# Check for disallowed script classes
-			for disallowed_script_class in ModLoaderStore.ml_options.disallowed_script_classes:
-				if file_string.contains("%s." % disallowed_script_class):
-					ModLoaderLog.warning("Script with call to \"%s\" detected!" % disallowed_script_class, LOG_NAME)
+			# Check for disallowed script strings
+			for disallowed_script_string in ModLoaderStore.ml_options.disallowed_strings_in_script_files:
+				if file_string.contains("%s" % disallowed_script_string):
+					ModLoaderLog.warning("Script with string \"%s\" detected!" % disallowed_script_string, LOG_NAME)
 					contains_disallowed_content = true
 
 		if file_extension == "tscn":
-			# Check for disallowed scene nodes
-			for disallowed_scene_node in ModLoaderStore.ml_options.disallowed_scene_nodes:
-				if file_string.contains(disallowed_scene_node):
-					ModLoaderLog.warning("Scene with disallowed Node \"%s\" detected!" % disallowed_scene_node, LOG_NAME)
+			# Check for disallowed scene strings
+			for disallowed_scene_string in ModLoaderStore.ml_options.disallowed_strings_in_scene_files:
+				if file_string.contains(disallowed_scene_string):
+					ModLoaderLog.warning("Scene with string \"%s\" detected!" % disallowed_scene_string, LOG_NAME)
 					contains_disallowed_content = true
 
 	reader.close()

--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -129,10 +129,13 @@ static func load_zips_in_folder(folder_path: String) -> Dictionary:
 
 		var mod_zip_path := folder_path.path_join(mod_zip_file_name)
 		var mod_zip_global_path := ProjectSettings.globalize_path(mod_zip_path)
-		var contains_disallowed_content := scan_zip(mod_zip_path)
-		if contains_disallowed_content:
-			ModLoaderLog.warning("disallowed mod content detected - skipped mod from path \"%s\"" % mod_zip_path, LOG_NAME)
-			continue
+
+		if ModLoaderStore.ml_options.enable_mod_scan:
+			var contains_disallowed_content := scan_zip(mod_zip_path)
+			if contains_disallowed_content:
+				ModLoaderLog.warning("disallowed mod content detected - skipped mod from path \"%s\"" % mod_zip_path, LOG_NAME)
+				continue
+
 		var is_mod_loaded_successfully := ProjectSettings.load_resource_pack(mod_zip_global_path, false)
 
 		# Get the current directories inside UNPACKED_DIR

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -148,6 +148,12 @@ var ml_options := {
 	load_from_steam_workshop = false,
 	# Indicates whether to load mods from the "mods" folder located at the game's install directory, or the overridden mods path.
 	load_from_local = true,
+
+	# Mod Scan - Settings for scanning mods before loading them into the game's mods-unpacked directory and executing any code
+	enable_mod_scan = false,
+	disallowed_script_classes = [],
+	disallowed_scene_nodes = [],
+	allowed_file_extensions = [],
 }
 
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -149,10 +149,10 @@ var ml_options := {
 	# Indicates whether to load mods from the "mods" folder located at the game's install directory, or the overridden mods path.
 	load_from_local = true,
 
-	# Mod Scan - Settings for scanning mods before loading them into the game's mods-unpacked directory and executing any code
+	# Mod Scan - Settings for scanning mods before loading them into the game's mods-unpacked directory.
 	enable_mod_scan = false,
-	disallowed_script_classes = [],
-	disallowed_scene_nodes = [],
+	disallowed_strings_in_script_files = [],
+	disallowed_strings_in_scene_files = [],
 	allowed_file_extensions = [],
 }
 

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -28,9 +28,27 @@ extends Resource
 ## Please check the Wiki FAQ for additional information on sandboxing and security.[br][br]
 ## Enable scanning mod zips before loading them into the game.
 @export var enable_mod_scan := false
-## Array to specify disallowed script classes
-@export var disallowed_script_classes: Array[StringName] = ["OS", "FileAccess", "DirAccess", "Script", "GDScript", "HTTPClient", "HTTPRequest", "WebSocketPeer", "WebRTCDataChannel", "WebRTCDataChannelExtension", "WebRTCMultiplayerPeer", "WebRTCPeerConnection", "WebRTCPeerConnectionExtension", "WebSocketMultiplayerPeer"]
-## Array to specify disallowed scene nodes
-@export var disallowed_scene_nodes: Array[StringName] = ["HTTPRequest"]
+## Array to specify disallowed strings in script files
+@export var disallowed_strings_in_script_files: Array[StringName] = [
+	"OS",
+	"FileAccess",
+	"DirAccess",
+	"Script",
+	"GDScript",
+	"HTTPClient",
+	"HTTPRequest",
+	"WebSocketPeer",
+	"WebRTCDataChannel",
+	"WebRTCDataChannelExtension",
+	"WebRTCMultiplayerPeer",
+	"WebRTCPeerConnection",
+	"WebRTCPeerConnectionExtension",
+	"WebSocketMultiplayerPeer",
+	"ml_options",
+	"res://addons/mod_loader/internal/file.gd",
+	"_ModLoaderFile",
+]
+## Array to specify disallowed strings in scene files
+@export var disallowed_strings_in_scene_files: Array[StringName] = ["HTTPRequest"]
 ## Array to specify allowed file extensions in mod zips
 @export var allowed_file_extensions: Array[StringName] = ["tscn", "tres", "gd", "svg", "png", "jpg", "anim"]

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -24,7 +24,7 @@ extends Resource
 @export var load_from_local: bool = true
 ## Settings for scanning mods before loading them into the game's mods-unpacked directory and executing any code
 @export_group("Mod Scan")
-## [b]!!! This is just a small security measure, it will not make modding safe. !!![/b][br]
+## [b]!!! This is not a security measure, it will not make modding safe. !!![/b][br]
 ## Please check the Wiki FAQ for additional information on sandboxing and security.[br][br]
 ## Enable scanning mod zips before loading them into the game.
 @export var enable_mod_scan := false

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -22,3 +22,15 @@ extends Resource
 @export var load_from_steam_workshop: bool = false
 ## Indicates whether to load mods from the "mods" folder located at the game's install directory, or the overridden mods path.
 @export var load_from_local: bool = true
+## Settings for scanning mods before loading them into the game's mods-unpacked directory and executing any code
+@export_group("Mod Scan")
+## [b]!!! This is just a small security measure, it will not make modding safe. !!![/b][br]
+## Please check the Wiki FAQ for additional information on sandboxing and security.[br][br]
+## Enable scanning mod zips before loading them into the game.
+@export var enable_mod_scan := false
+## Array to specify disallowed script classes
+@export var disallowed_script_classes: Array[StringName] = ["OS", "FileAccess", "DirAccess", "Script", "GDScript", "HTTPClient", "HTTPRequest", "WebSocketPeer", "WebRTCDataChannel", "WebRTCDataChannelExtension", "WebRTCMultiplayerPeer", "WebRTCPeerConnection", "WebRTCPeerConnectionExtension", "WebSocketMultiplayerPeer"]
+## Array to specify disallowed scene nodes
+@export var disallowed_scene_nodes: Array[StringName] = ["HTTPRequest"]
+## Array to specify allowed file extensions in mod zips
+@export var allowed_file_extensions: Array[StringName] = ["tscn", "tres", "gd", "svg", "png", "jpg", "anim"]


### PR DESCRIPTION
Optional scanning feature for mod ZIP files before they are loaded into the game.

**Please note: 
This feature is not a security measure. It simply scans `gd` and `tscn` files for specific disallowed strings.**

---

Changes include:

- **New Function**: `_ModLoaderFile.scan_zip(zip_path: String)`
  - Scans a ZIP file for disallowed content.
  - Returns `true` if disallowed content is found, `false` otherwise.

- **New `ml_options` Variables** with [default values](https://github.com/GodotModding/godot-mod-loader/blob/5c902cff614ac949d4d51d318e3c2c440553a1c6/addons/mod_loader/resources/options_profile.gd#L32-L54):
  - `enable_mod_scan`
  - `disallowed_strings_in_script_files`
  - `disallowed_strings_in_scene_files`
  - `allowed_file_extensions`

- `enable_mod_scan` is disabled by default to avoid increasing loading times and potentially restricting the scope of modding.