### PR TITLE
feat: :sparkles: added `is_mod_active` to `ModLoaderMod`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -161,3 +161,17 @@ static func is_mod_loaded(mod_id: String) -> bool:
 		return false
 
 	return true
+
+
+# Returns true if the mod with the given mod_id was successfully loaded and is currently active.
+#
+# Parameters:
+# - mod_id (String): The ID of the mod.
+#
+# Returns:
+# - bool: true if the mod is loaded and active, false otherwise.
+static func is_mod_active(mod_id: String) -> bool:
+	if ModLoaderMod.is_mod_loaded(mod_id) and ModLoaderMod.get_mod_data(mod_id).is_active:
+		return true
+
+	return false

--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -171,7 +171,4 @@ static func is_mod_loaded(mod_id: String) -> bool:
 # Returns:
 # - bool: true if the mod is loaded and active, false otherwise.
 static func is_mod_active(mod_id: String) -> bool:
-	if ModLoaderMod.is_mod_loaded(mod_id) and ModLoaderMod.get_mod_data(mod_id).is_active:
-		return true
-
-	return false
+	return is_mod_loaded(mod_id) and ModLoaderStore.mod_data[mod_id].is_active


### PR DESCRIPTION
Added  `static func is_mod_active(mod_id: String) -> bool:` to `ModLoaderMod`.

closes #355 (maybe we want to keep it open for 3.5?)