### PR TITLE
refactor: :fire: removed `steam_workshop_enabled` option

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -234,7 +234,7 @@ func _load_mod_zips() -> Dictionary:
 		var loaded_zip_data := _ModLoaderFile.load_zips_in_folder(mods_folder_path)
 		zip_data.merge(loaded_zip_data)
 
-	if ModLoaderStore.ml_options.load_from_steam_workshop or ModLoaderStore.ml_options.steam_workshop_enabled:
+	if ModLoaderStore.ml_options.load_from_steam_workshop:
 		# If we're using Steam workshop, loop over the workshop item directories
 		var loaded_workshop_zip_data := _ModLoaderSteam.load_steam_workshop_zips()
 		zip_data.merge(loaded_workshop_zip_data)

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -117,11 +117,6 @@ var ml_options := {
 	# The ModLoaderStore Autoload still needs to be placed before the ModLoader Autoload.
 	allow_modloader_autoloads_anywhere = false,
 
-	# If true, ModLoader will load mod ZIPs from the Steam workshop directory,
-	# instead of the default location (res://mods)
-	# INFO: Redundant since the introduction of mod source options, kept for backwards compatibility.
-	steam_workshop_enabled = false,
-
 	# Application's Steam ID, used if workshop is enabled
 	steam_id = 0,
 

--- a/addons/mod_loader/options/profiles/production_no_workshop.tres
+++ b/addons/mod_loader/options/profiles/production_no_workshop.tres
@@ -1,14 +1,19 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="ModLoaderOptionsProfile" load_steps=2 format=4 uid="uid://bodsw0jyh6rn5"]
 
-[ext_resource path="res://addons/mod_loader/resources/options_profile.gd" type="Script" id=1]
-
+[ext_resource type="Script" path="res://addons/mod_loader/resources/options_profile.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 enable_mods = true
+locked_mods = Array[String]([])
 log_level = 2
-disabled_mods = [  ]
-steam_workshop_enabled = false
+disabled_mods = Array[String]([])
+allow_modloader_autoloads_anywhere = false
+steam_id = 0
 override_path_to_mods = ""
 override_path_to_configs = ""
 override_path_to_workshop = ""
+ignore_deprecated_errors = false
+ignored_mod_names_in_log = Array[String]([])
+load_from_steam_workshop = false
+load_from_local = true

--- a/addons/mod_loader/options/profiles/production_workshop.tres
+++ b/addons/mod_loader/options/profiles/production_workshop.tres
@@ -1,14 +1,19 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="ModLoaderOptionsProfile" load_steps=2 format=4 uid="uid://cg0vv5k4o71rv"]
 
-[ext_resource path="res://addons/mod_loader/resources/options_profile.gd" type="Script" id=1]
-
+[ext_resource type="Script" path="res://addons/mod_loader/resources/options_profile.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 enable_mods = true
+locked_mods = Array[String]([])
 log_level = 2
-disabled_mods = [  ]
-steam_workshop_enabled = true
+disabled_mods = Array[String]([])
+allow_modloader_autoloads_anywhere = false
+steam_id = 0
 override_path_to_mods = ""
 override_path_to_configs = ""
 override_path_to_workshop = ""
+ignore_deprecated_errors = false
+ignored_mod_names_in_log = Array[String]([])
+load_from_steam_workshop = true
+load_from_local = true

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -10,7 +10,6 @@ extends Resource
 @export var log_level := ModLoaderLog.VERBOSITY_LEVEL.DEBUG
 @export var disabled_mods: Array[String] = []
 @export var allow_modloader_autoloads_anywhere: bool = false
-@export var steam_workshop_enabled: bool = false
 @export var steam_id: int = 0
 @export_dir var override_path_to_mods = ""
 @export_dir var override_path_to_configs = ""


### PR DESCRIPTION
It has been replaced by the `load_from_steam_workshop` option in #369 

closes #384