### PR TITLE
feat: ✨ `create_deactivated_mods_profile` option added 

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -192,11 +192,11 @@ static func get_all_as_array() -> Array:
 # =============================================================================
 
 
-# Update the global list of disabled mods based on the current user profile
-# The user profile will override the disabled_mods property that can be set via the options resource in the editor.
-# Example: If "Mod-TestMod" is set in disabled_mods via the editor, the mod will appear disabled in the user profile.
-# If the user then enables the mod in the profile the entry in disabled_mods will be removed.
-static func _update_disabled_mods() -> void:
+# Update the global list of deactivated mods based on the current user profile
+# The user profile will override the deactivated_mods property that can be set via the options resource in the editor.
+# Example: If "Mod-TestMod" is set in deactivated_mods via the editor, the mod will appear deactivated in the user profile.
+# If the user then enables the mod in the profile the entry in deactivated_mods will be removed.
+static func _update_deactivated_mods() -> void:
 	var current_user_profile: ModUserProfile = get_current()
 
 	# Check if a current user profile is set
@@ -204,7 +204,7 @@ static func _update_disabled_mods() -> void:
 		ModLoaderLog.info("There is no current user profile. The \"default\" profile will be created.", LOG_NAME)
 		return
 
-	# Iterate through the mod list in the current user profile to find disabled mods
+	# Iterate through the mod list in the current user profile to find deactivated mods
 	for mod_id in current_user_profile.mod_list:
 		var mod_list_entry: Dictionary = current_user_profile.mod_list[mod_id]
 		if ModLoaderStore.mod_data.has(mod_id):
@@ -221,7 +221,7 @@ static func _update_disabled_mods() -> void:
 # Additionally, it checks for and deletes any mods from each profile's mod list that are no longer installed on the system.
 static func _update_mod_lists() -> bool:
 	# Generate a list of currently present mods by combining the mods
-	# in mod_data and ml_options.disabled_mods from ModLoaderStore.
+	# in mod_data and ml_options.deactivated_mods from ModLoaderStore.
 	var current_mod_list := _generate_mod_list()
 
 	# Iterate over all user profiles
@@ -297,7 +297,7 @@ static func _generate_mod_list() -> Dictionary:
 		mod_list[mod_id] = _generate_mod_list_entry(mod_id, true)
 
 	# Add the deactivated mods to the list
-	for mod_id in ModLoaderStore.ml_options.disabled_mods:
+	for mod_id in ModLoaderStore.ml_options.deactivated_mods:
 		mod_list[mod_id] = _generate_mod_list_entry(mod_id, false)
 
 	return mod_list
@@ -404,9 +404,9 @@ static func _load() -> bool:
 	# Load JSON data from the user profiles file
 	var data := _ModLoaderFile.get_json_as_dict(FILE_PATH_USER_PROFILES)
 
-	# If there is no data, log an error and return
+	# If there is no data, log an info and return
 	if data.is_empty():
-		ModLoaderLog.error("No profile file found at \"%s\"" % FILE_PATH_USER_PROFILES, LOG_NAME)
+		ModLoaderLog.info("No profile file found at \"%s\"" % FILE_PATH_USER_PROFILES, LOG_NAME)
 		return false
 
 	# Loop through each profile in the data and add them to ModLoaderStore

--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -3,12 +3,10 @@ extends Object
 ##
 ## This Class provides methods for working with user profiles.
 
-
 const LOG_NAME := "ModLoader:UserProfile"
 
 # The path where the Mod User Profiles data is stored.
 const FILE_PATH_USER_PROFILES := "user://mod_user_profiles.json"
-
 
 # API profile functions
 # =============================================================================
@@ -21,11 +19,11 @@ const FILE_PATH_USER_PROFILES := "user://mod_user_profiles.json"
 ## - [code]user_profile[/code] ([ModUserProfile]): (Optional) The user profile to enable the mod for. Default is the current user profile.[br]
 ## [br]
 ## [b]Returns:[/b] [bool]
-static func enable_mod(mod_id: String, user_profile:= ModLoaderStore.current_user_profile) -> bool:
+static func enable_mod(mod_id: String, user_profile := ModLoaderStore.current_user_profile) -> bool:
 	return _set_mod_state(mod_id, user_profile.name, true)
 
 
-## Disables a mod - it will not be loaded on the next game start[br]
+## Disables a mod - it will not be loaded on the next game start.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
 ## - [code]mod_id[/code] ([String]): The ID of the mod to disable.[br]
@@ -36,15 +34,31 @@ static func disable_mod(mod_id: String, user_profile := ModLoaderStore.current_u
 	return _set_mod_state(mod_id, user_profile.name, false)
 
 
-## Sets the current config for a mod in a user profile's mod_list.[br]
+## Disables all mods - they will not be loaded on the next game start.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]mod_id[/code] ([String]): The ID of the mod.[br]
-## - [code]mod_config[/code] ([ModConfig]): The mod config to set as the current config.[br]
-## - [code]user_profile[/code] ([ModUserProfile]): (Optional) The user profile to update. Default is the current user profile.[br]
+## - [code]user_profile[/code] ([ModUserProfile]): (Optional) The user profile to disable the mod for. Default is the current user profile.[br]
 ## [br]
 ## [b]Returns:[/b] [bool]
-static func set_mod_current_config(mod_id: String, mod_config: ModConfig, user_profile := ModLoaderStore.current_user_profile) -> bool:
+static func disable_all_mods(user_profile := ModLoaderStore.current_user_profile) -> bool:
+	for mod_id in user_profile.mod_list.keys():
+		if not _set_mod_state(mod_id, user_profile.name, false):
+			return false
+
+	return true
+
+
+# Sets the current config for a mod in a user profile's mod_list.
+#
+# Parameters:
+# - mod_id (String): The ID of the mod.
+# - mod_config (ModConfig): The mod config to set as the current config.
+# - user_profile (ModUserProfile): (Optional) The user profile to update. Default is the current user profile.
+#
+# Returns: bool
+static func set_mod_current_config(
+	mod_id: String, mod_config: ModConfig, user_profile := ModLoaderStore.current_user_profile
+) -> bool:
 	# Verify whether the mod_id is present in the profile's mod_list.
 	if not _is_mod_id_in_mod_list(mod_id, user_profile.name):
 		return false
@@ -56,7 +70,13 @@ static func set_mod_current_config(mod_id: String, mod_config: ModConfig, user_p
 	var is_save_success := _save()
 
 	if is_save_success:
-		ModLoaderLog.debug("Set the \"current_config\" of \"%s\" to \"%s\" in user profile \"%s\" " % [mod_id, mod_config.name, user_profile.name], LOG_NAME)
+		ModLoaderLog.debug(
+			(
+				'Set the "current_config" of "%s" to "%s" in user profile "%s" '
+				% [mod_id, mod_config.name, user_profile.name]
+			),
+			LOG_NAME
+		)
 
 	return is_save_success
 
@@ -70,7 +90,9 @@ static func set_mod_current_config(mod_id: String, mod_config: ModConfig, user_p
 static func create_profile(profile_name: String) -> bool:
 	# Verify that the profile name is not already in use
 	if ModLoaderStore.user_profiles.has(profile_name):
-		ModLoaderLog.error("User profile with the name of \"%s\" already exists." % profile_name, LOG_NAME)
+		ModLoaderLog.error(
+			'User profile with the name of "%s" already exists.' % profile_name, LOG_NAME
+		)
 		return false
 
 	var mod_list := _generate_mod_list()
@@ -91,7 +113,7 @@ static func create_profile(profile_name: String) -> bool:
 	var is_save_success := _save()
 
 	if is_save_success:
-		ModLoaderLog.debug("Created new user profile \"%s\"" % profile_name, LOG_NAME)
+		ModLoaderLog.debug('Created new user profile "%s"' % profile_name, LOG_NAME)
 
 	return is_save_success
 
@@ -105,7 +127,7 @@ static func create_profile(profile_name: String) -> bool:
 static func set_profile(user_profile: ModUserProfile) -> bool:
 	# Check if the profile name is unique
 	if not ModLoaderStore.user_profiles.has(user_profile.name):
-		ModLoaderLog.error("User profile with name \"%s\" not found." % user_profile.name, LOG_NAME)
+		ModLoaderLog.error('User profile with name "%s" not found.' % user_profile.name, LOG_NAME)
 		return false
 
 	# Update the current_user_profile in the ModLoaderStore
@@ -115,7 +137,7 @@ static func set_profile(user_profile: ModUserProfile) -> bool:
 	var is_save_success := _save()
 
 	if is_save_success:
-		ModLoaderLog.debug("Current user profile set to \"%s\"" % user_profile.name, LOG_NAME)
+		ModLoaderLog.debug('Current user profile set to "%s"' % user_profile.name, LOG_NAME)
 
 	return is_save_success
 
@@ -129,10 +151,18 @@ static func set_profile(user_profile: ModUserProfile) -> bool:
 static func delete_profile(user_profile: ModUserProfile) -> bool:
 	# If the current_profile is about to get deleted log an error
 	if ModLoaderStore.current_user_profile.name == user_profile.name:
-		ModLoaderLog.error(str(
-			"You cannot delete the currently selected user profile \"%s\" " +
-			"because it is currently in use. Please switch to a different profile before deleting this one.") % user_profile.name,
-		LOG_NAME)
+		ModLoaderLog.error(
+			(
+				str(
+					(
+						'You cannot delete the currently selected user profile "%s" '
+						+ "because it is currently in use. Please switch to a different profile before deleting this one."
+					)
+				)
+				% user_profile.name
+			),
+			LOG_NAME
+		)
 		return false
 
 	# Deleting the default profile is not allowed
@@ -143,14 +173,14 @@ static func delete_profile(user_profile: ModUserProfile) -> bool:
 	# Delete the user profile
 	if not ModLoaderStore.user_profiles.erase(user_profile.name):
 		# Erase returns false if the the key is not present in user_profiles
-		ModLoaderLog.error("User profile with name \"%s\" not found." % user_profile.name, LOG_NAME)
+		ModLoaderLog.error('User profile with name "%s" not found.' % user_profile.name, LOG_NAME)
 		return false
 
 	# Save profiles to the user profiles JSON file
 	var is_save_success := _save()
 
 	if is_save_success:
-		ModLoaderLog.debug("Deleted user profile \"%s\"" % user_profile.name, LOG_NAME)
+		ModLoaderLog.debug('Deleted user profile "%s"' % user_profile.name, LOG_NAME)
 
 	return is_save_success
 
@@ -170,7 +200,7 @@ static func get_current() -> ModUserProfile:
 ## [b]Returns:[/b] [ModUserProfile] or [code]null[/code] if not found
 static func get_profile(profile_name: String) -> ModUserProfile:
 	if not ModLoaderStore.user_profiles.has(profile_name):
-		ModLoaderLog.error("User profile with name \"%s\" not found." % profile_name, LOG_NAME)
+		ModLoaderLog.error('User profile with name "%s" not found.' % profile_name, LOG_NAME)
 		return null
 
 	return ModLoaderStore.user_profiles[profile_name]
@@ -201,7 +231,9 @@ static func _update_deactivated_mods() -> void:
 
 	# Check if a current user profile is set
 	if not current_user_profile:
-		ModLoaderLog.info("There is no current user profile. The \"default\" profile will be created.", LOG_NAME)
+		ModLoaderLog.info(
+			'There is no current user profile. The "default" profile will be created.', LOG_NAME
+		)
 		return
 
 	# Iterate through the mod list in the current user profile to find deactivated mods
@@ -211,9 +243,12 @@ static func _update_deactivated_mods() -> void:
 			ModLoaderStore.mod_data[mod_id].is_active = mod_list_entry.is_active
 
 	ModLoaderLog.debug(
-		"Updated the active state of all mods, based on the current user profile \"%s\""
-		% current_user_profile.name,
-	LOG_NAME)
+		(
+			'Updated the active state of all mods, based on the current user profile "%s"'
+			% current_user_profile.name
+		),
+		LOG_NAME
+	)
 
 
 # This function updates the mod lists of all user profiles with newly loaded mods that are not already present.
@@ -257,25 +292,30 @@ static func _update_mod_list(mod_list: Dictionary, mod_data := ModLoaderStore.mo
 
 		# Check if the current config doesn't exist
 		# This can happen if the config file was manually deleted
-		if mod_list_entry.has("current_config") and _ModLoaderPath.get_path_to_mod_config_file(mod_id, mod_list_entry.current_config).is_empty():
+		if (
+			mod_list_entry.has("current_config")
+			and _ModLoaderPath.get_path_to_mod_config_file(mod_id, mod_list_entry.current_config).is_empty()
+		):
 			# If the current config doesn't exist, reset it to the default configuration
 			mod_list_entry.current_config = ModLoaderConfig.DEFAULT_CONFIG_NAME
 
 		if (
 			# If the mod is not loaded
-			not mod_data.has(mod_id) and
+			not mod_data.has(mod_id)
 			# Check if the entry has a zip_path key
-			mod_list_entry.has("zip_path") and
+			and mod_list_entry.has("zip_path")
 			# Check if the entry has a zip_path
-			not mod_list_entry.zip_path.is_empty() and
+			and not mod_list_entry.zip_path.is_empty()
 			# Check if the zip file for the mod doesn't exist
-			not _ModLoaderFile.file_exists(mod_list_entry.zip_path)
+			and not _ModLoaderFile.file_exists(mod_list_entry.zip_path)
 		):
 			# If the mod directory doesn't exist,
 			# the mod is no longer installed and can be removed from the mod list
 			ModLoaderLog.debug(
-				"Mod \"%s\" has been deleted from all user profiles as the corresponding zip file no longer exists at path \"%s\"."
-				% [mod_id, mod_list_entry.zip_path],
+				(
+					'Mod "%s" has been deleted from all user profiles as the corresponding zip file no longer exists at path "%s".'
+					% [mod_id, mod_list_entry.zip_path]
+				),
 				LOG_NAME,
 				true
 			)
@@ -337,9 +377,12 @@ static func _set_mod_state(mod_id: String, profile_name: String, activate: bool)
 	# Check if it is a locked mod
 	if ModLoaderStore.mod_data.has(mod_id) and ModLoaderStore.mod_data[mod_id].is_locked:
 		ModLoaderLog.error(
-			"Unable to disable mod \"%s\" as it is marked as locked. Locked mods: %s"
-			% [mod_id, ModLoaderStore.ml_options.locked_mods],
-		LOG_NAME)
+			(
+				'Unable to disable mod "%s" as it is marked as locked. Locked mods: %s'
+				% [mod_id, ModLoaderStore.ml_options.locked_mods]
+			),
+			LOG_NAME
+		)
 		return false
 
 	# Handle mod state
@@ -352,7 +395,13 @@ static func _set_mod_state(mod_id: String, profile_name: String, activate: bool)
 	var is_save_success := _save()
 
 	if is_save_success:
-		ModLoaderLog.debug("Mod activation state changed: mod_id=%s activate=%s profile_name=%s" % [mod_id, activate, profile_name], LOG_NAME)
+		ModLoaderLog.debug(
+			(
+				"Mod activation state changed: mod_id=%s activate=%s profile_name=%s"
+				% [mod_id, activate, profile_name]
+			),
+			LOG_NAME
+		)
 
 	return is_save_success
 
@@ -368,7 +417,13 @@ static func _is_mod_id_in_mod_list(mod_id: String, profile_name: String) -> bool
 
 	# Return false if the mod_id is not in the profile's mod_list
 	if not user_profile.mod_list.has(mod_id):
-		ModLoaderLog.error("Mod id \"%s\" not found in the \"mod_list\" of user profile \"%s\"." % [mod_id, profile_name], LOG_NAME)
+		ModLoaderLog.error(
+			(
+				'Mod id "%s" not found in the "mod_list" of user profile "%s".'
+				% [mod_id, profile_name]
+			),
+			LOG_NAME
+		)
 		return false
 
 	# Return true if the mod_id is in the profile's mod_list
@@ -390,7 +445,9 @@ static func _create_new_profile(profile_name: String, mod_list: Dictionary) -> M
 
 	# If no mods are specified in the mod_list, log a warning and return the new profile
 	if mod_list.keys().size() == 0:
-		ModLoaderLog.info("No mod_ids inside \"mod_list\" for user profile \"%s\" " % profile_name, LOG_NAME)
+		ModLoaderLog.info(
+			'No mod_ids inside "mod_list" for user profile "%s" ' % profile_name, LOG_NAME
+		)
 		return new_profile
 
 	# Set the mod_list
@@ -406,7 +463,7 @@ static func _load() -> bool:
 
 	# If there is no data, log an info and return
 	if data.is_empty():
-		ModLoaderLog.info("No profile file found at \"%s\"" % FILE_PATH_USER_PROFILES, LOG_NAME)
+		ModLoaderLog.info('No profile file found at "%s"' % FILE_PATH_USER_PROFILES, LOG_NAME)
 		return false
 
 	# Loop through each profile in the data and add them to ModLoaderStore
@@ -427,10 +484,7 @@ static func _load() -> bool:
 # Saves the user profiles in the ModLoaderStore to the user profiles JSON file.
 static func _save() -> bool:
 	# Initialize a dictionary to hold the serialized user profiles data
-	var save_dict := {
-		"current_profile": "",
-		"profiles": {}
-	}
+	var save_dict := {"current_profile": "", "profiles": {}}
 
 	# Set the current profile name in the save_dict
 	save_dict.current_profile = ModLoaderStore.current_user_profile.name

--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -5,8 +5,8 @@ extends RefCounted
 # This Class provides util functions for working with paths.
 # Currently all of the included functions are internal and should only be used by the mod loader itself.
 
-const LOG_NAME := "ModLoader:Path3D"
-const MOD_CONFIG_DIR_PATH := "user://configs"
+const LOG_NAME := "ModLoader:Path"
+const MOD_CONFIG_DIR_PATH := "user://mod_configs"
 
 
 # Get the path to a local folder. Primarily used to get the  (packed) mods

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -115,6 +115,14 @@ func _load_mods() -> void:
 	# This should only occur on the first run of the game or if the JSON file was manually edited.
 	if not ModLoaderStore.user_profiles.has("default"):
 		var _success_user_profile_create := ModLoaderUserProfile.create_profile("default")
+	
+	# Create a user profile with all mods deactivated if the option is enabled.
+	if (
+		ModLoaderStore.ml_options.create_deactivated_mods_profile and
+		not ModLoaderStore.user_profiles.has(ModLoaderStore.ml_options.deactivated_mods_profile_name)
+	): 
+		if ModLoaderUserProfile.create_profile(ModLoaderStore.ml_options.deactivated_mods_profile_name):
+			ModLoaderUserProfile.disable_all_mods()
 
 	# Load Mod Configs
 	for dir_name in ModLoaderStore.mod_data:

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -63,11 +63,6 @@ func _init() -> void:
 
 
 func _ready():
-	# Create the default user profile if it doesn't exist already
-	# This should always be present unless the JSON file was manually edited
-	if not ModLoaderStore.user_profiles.has("default"):
-		var _success_user_profile_create := ModLoaderUserProfile.create_profile("default")
-
 	# Update the mod_list for each user profile
 	var _success_update_mod_lists := ModLoaderUserProfile._update_mod_lists()
 
@@ -104,7 +99,7 @@ func _load_mods() -> void:
 		ModLoaderLog.info("No mods were setup", LOG_NAME)
 
 	# Update active state of mods based on the current user profile
-	ModLoaderUserProfile._update_disabled_mods()
+	ModLoaderUserProfile._update_deactivated_mods()
 
 	# Loop over all loaded mods via their entry in mod_data. Verify that they
 	# have all the required files (REQUIRED_MOD_FILES), load their meta data
@@ -113,10 +108,21 @@ func _load_mods() -> void:
 	for dir_name in ModLoaderStore.mod_data:
 		var mod: ModData = ModLoaderStore.mod_data[dir_name]
 		mod.load_manifest()
+
+	ModLoaderLog.success("DONE: Loaded all meta data", LOG_NAME)
+
+	# Create the default user profile if it doesn't already exist.
+	# This should only occur on the first run of the game or if the JSON file was manually edited.
+	if not ModLoaderStore.user_profiles.has("default"):
+		var _success_user_profile_create := ModLoaderUserProfile.create_profile("default")
+
+	# Load Mod Configs
+	for dir_name in ModLoaderStore.mod_data:
+		var mod: ModData = ModLoaderStore.mod_data[dir_name]
 		if mod.manifest.get("config_schema") and not mod.manifest.config_schema.is_empty():
 			mod.load_configs()
 
-	ModLoaderLog.success("DONE: Loaded all meta data", LOG_NAME)
+	ModLoaderLog.success("DONE: Loaded all mod configs", LOG_NAME)
 
 	# Check for mods with load_before. If a mod is listed in load_before,
 	# add the current mod to the dependencies of the the mod specified
@@ -278,10 +284,6 @@ func _setup_mods() -> int:
 		):
 			continue
 
-		if ModLoaderStore.ml_options.disabled_mods.has(mod_dir_name):
-			ModLoaderLog.info("Skipped setting up mod: \"%s\"" % mod_dir_name, LOG_NAME)
-			continue
-
 		# Initialize the mod data for each mod if there is no existing mod data for that mod.
 		if not ModLoaderStore.mod_data.has(mod_dir_name):
 			_init_mod_data(mod_dir_name)
@@ -309,6 +311,7 @@ func _init_mod_data(mod_id: String, zip_path := "") -> void:
 	var mod_overwrites_path := mod.get_optional_mod_file_path(ModData.optional_mod_files.OVERWRITES)
 	mod.is_overwrite = _ModLoaderFile.file_exists(mod_overwrites_path)
 	mod.is_locked = true if mod_id in ModLoaderStore.ml_options.locked_mods else false
+	mod.is_active = true if not ModLoaderStore.ml_options.deactivated_mods.has(mod_id) else false
 
 	ModLoaderStore.mod_data[mod_id] = mod
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -112,6 +112,15 @@ var ml_options := {
 
 	# Array of deactivated mods (contains mod IDs as strings)
 	deactivated_mods = [],
+	
+	# Generate a user profile with all mods deactivated.
+	# This can be used after a major game update to prevent crashes.
+	create_deactivated_mods_profile = false,
+	
+	# The name of the deactivated mods profile.
+	# Use this to customize the profile name. Make sure to change the name each time you want to deactivate all mods.
+	# The profile is only created if the name doesn't already exist. You can add a version suffix, for example.
+	deactivated_mods_profile_name = "deactivated_",
 
 	# If this flag is set to true, the ModLoaderStore and ModLoader Autoloads don't have to be the first Autoloads.
 	# The ModLoaderStore Autoload still needs to be placed before the ModLoader Autoload.

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -107,11 +107,11 @@ var ml_options := {
 	enable_mods = true,
 	log_level = ModLoaderLog.VERBOSITY_LEVEL.DEBUG,
 
-	# Mods that can't be disabled or enabled in a user profile (contains mod IDs as strings)
+	# Mods that can't be deactivated or enabled in a user profile (contains mod IDs as strings)
 	locked_mods = [],
 
-	# Array of disabled mods (contains mod IDs as strings)
-	disabled_mods = [],
+	# Array of deactivated mods (contains mod IDs as strings)
+	deactivated_mods = [],
 
 	# If this flag is set to true, the ModLoaderStore and ModLoader Autoloads don't have to be the first Autoloads.
 	# The ModLoaderStore Autoload still needs to be placed before the ModLoader Autoload.

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -47,7 +47,7 @@ var dir_path := ""
 var is_loadable := true
 ## True if overwrites.gd exists
 var is_overwrite := false
-## True if mod can't be disabled or enabled in a user profile
+# True if mod can't be deactivated or enabled in a user profile
 var is_locked := false
 ## Flag indicating whether the mod should be loaded
 var is_active := true
@@ -121,6 +121,10 @@ func _load_config(config_file_path: String) -> void:
 
 	# Add the config to the configs dictionary
 	configs[mod_config.name] = mod_config
+
+	# Set it as the current_config if there is none
+	if not current_config:
+		current_config = mod_config
 
 
 # Update the mod_list of the current user profile

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -9,6 +9,13 @@ extends Resource
 ## This can be used to deactivate example mods.
 ## Mods in this array are overridden by the settings in the user profile.
 @export var deactivated_mods: Array[String] = []
+## Generate a user profile with all mods deactivated.
+## This can be used after a major game update to prevent crashes.
+@export var create_deactivated_mods_profile = false
+## The name of the deactivated mods profile.
+## Use this to customize the profile name. Make sure to change the name each time you want to deactivate all mods.
+## The profile is only created if the name doesn't already exist. You can add a version suffix, for example.
+@export var deactivated_mods_profile_name = "deactivated_"
 @export var allow_modloader_autoloads_anywhere: bool = false
 @export var steam_id: int = 0
 @export_dir var override_path_to_mods = ""

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -5,7 +5,10 @@ extends Resource
 @export var enable_mods: bool = true
 @export var locked_mods: Array[String] = []
 @export var log_level := ModLoaderLog.VERBOSITY_LEVEL.DEBUG
-@export var disabled_mods: Array[String] = []
+## Mods in this array will only load metadata but will not apply any modifications.
+## This can be used to deactivate example mods.
+## Mods in this array are overridden by the settings in the user profile.
+@export var deactivated_mods: Array[String] = []
 @export var allow_modloader_autoloads_anywhere: bool = false
 @export var steam_id: int = 0
 @export_dir var override_path_to_mods = ""


### PR DESCRIPTION
Added `create_deactivated_mods_profile` and `deactivated_mods_profile_name` option. This can be used after a major game update to prevent crashes.

Tested with Windowkill 👍 


> [!IMPORTANT]  
> depends on #394 
