### PR TITLE
fix: do not ignore self setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,3 @@
 
 # Tests
 test/                                   export-ignore
-
-# Files not required by AssetLib downloads (provided via download for manual installers)
-addons/mod_loader/vendor/               export-ignore
-addons/mod_loader/mod_loader_setup.gd   export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 
 # Tests
 test/                                   export-ignore
+
+# Must be ignored as we don't want to distribute an exe through the AssetLib
+addons/mod_loader/vendor/               export-ignore


### PR DESCRIPTION
This is labeled as a fix, why? Better yet why make this PR in the first place? Isn't this feature here for good reason?

I do like the idea of ignoring the files not required by AssetLib downloads, but doing it this way has the caveat of ignoring these files when downloading the repo (at least from Github directly). To me is a **big** no no. It restricts the people who actually want to use the self setup, with the benefit of removing a couple extra files from the AssetLib download.

Overall I think these files are small and quite harmless to AssetLib downloads, while it's harmful to make it harder for people who need the self setup to get it.

> [!NOTE]  
> This PR targets the 4.x branch but applies to 3.x too