### PR TITLE
refactor: :recycle: check for `mod_data`

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -121,6 +121,9 @@ static func extend_scene(scene_vanilla_path: String, edit_callable: Callable) ->
 ## [br][b]Returns:[/b][br]
 ## - [ModData]: The [ModData] associated with the provided [code]mod_id[/code], or null if the [code]mod_id[/code] is invalid.[br]
 static func get_mod_data(mod_id: String) -> ModData:
+	if not ModLoaderStore.get("mod_data"):
+		return null
+
 	if not ModLoaderStore.mod_data.has(mod_id):
 		ModLoaderLog.error("%s is an invalid mod_id" % mod_id, LOG_NAME)
 		return null

--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -481,6 +481,9 @@ static func is_string_length_valid(mod_id: String, field: String, string: String
 
 static func is_steam_workshop_id_valid(mod_id: String, steam_workshop_id_to_validate: String, is_silent := false) -> bool:
 	var mod_data := ModLoaderMod.get_mod_data(mod_id)
+	if not mod_data:
+		# If there is no mod_data, we are probably working with the mod dev tool
+		return true
 	var mod_source := mod_data.get_mod_source()
 	var steam_workshop_id_from_path := ""
 


### PR DESCRIPTION
Changes made to get rid of errors in the [Mod Dev Tool](https://github.com/GodotModding/godot-mod-tool/pull/110).
```
res://addons/mod_loader/api/mod.gd:145 - Invalid access to property or key 'mod_data' on a base object of type 'Node (mod_loader_store.gd)'.
res://addons/mod_loader/resources/mod_manifest.gd:484 - Invalid call. Nonexistent function 'get_mod_source' in base 'Nil'.
```

`mod_data` is empty when working with the mod dev tool