### PR TITLE
fix: broken TranslationServer when added translation fails to load

### DIFF
--- a/addons/mod_loader/api/mod.gd
+++ b/addons/mod_loader/api/mod.gd
@@ -73,8 +73,12 @@ static func add_translation(resource_path: String) -> void:
 		return
 
 	var translation_object: Translation = load(resource_path)
-	TranslationServer.add_translation(translation_object)
-	ModLoaderLog.info("Added Translation from Resource -> %s" % resource_path, LOG_NAME)
+	if translation_object:
+		TranslationServer.add_translation(translation_object)
+		ModLoaderLog.info("Added Translation from Resource -> %s" % resource_path, LOG_NAME)
+	else:
+		ModLoaderLog.fatal("Failed to load translation at path: %s" % [resource_path], LOG_NAME)
+	
 
 ## [i]Note: This function requires Godot 4.3 or higher.[/i][br]
 ##[br]


### PR DESCRIPTION
Adds a null check to ensure broken translation files don't break the game's localization.

Godots translation.cpp has no safety checks when calling TranslationServer::add_translation. (as of 4.2.2)
If for any reason a null-object is passed to it it will cause the translation server to break for the entire session.

