### PR TITLE
refactor: :recycle: updated `hook_pre_processor` reference

### DIFF
--- a/addons/mod_loader/_export_plugin/export_plugin.gd
+++ b/addons/mod_loader/_export_plugin/export_plugin.gd
@@ -1,16 +1,15 @@
 extends EditorExportPlugin
 
-const ModHookPreprocessorScript := preload("res://addons/mod_loader/internal/mod_hook_preprocessor.gd")
-static var ModHookPreprocessor: ModLoaderHookPreprocessor
 
+static var hook_pre_processor: _ModLoaderModHookPreProcessor
 
 func _get_name() -> String:
 	return "Godot Mod Loader Export Plugin"
 
 
 func _export_begin(features: PackedStringArray, is_debug: bool, path: String, flags: int) -> void:
-	ModHookPreprocessor = ModHookPreprocessorScript.new()
-	ModHookPreprocessor.process_begin()
+	hook_pre_processor = _ModLoaderModHookPreProcessor.new()
+	hook_pre_processor.process_begin()
 
 
 func _export_file(path: String, type: String, features: PackedStringArray) -> void:
@@ -23,6 +22,6 @@ func _export_file(path: String, type: String, features: PackedStringArray) -> vo
 	skip()
 	add_file(
 		path,
-		ModHookPreprocessor.process_script(path).to_utf8_buffer(),
+		hook_pre_processor.process_script(path).to_utf8_buffer(),
 		false
 	)


### PR DESCRIPTION
Updates the class reference used in *export_plugin.gd* from `ModLoaderHookPreprocessor` to `_ModLoaderModHookPreProcessor`