### PR TITLE
fix: :bug: fixed super fixing

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -152,7 +152,9 @@ static func get_function_parameters(method_name: String, text: String, is_static
 	if not is_top_level_func(text, result.get_start(), is_static):
 		return get_function_parameters(method_name, text, is_static, result.get_end())
 
-	var closing_paren_index := get_closing_paren_index(opening_paren_index, text)
+	# Shift the func_def_end index back by one to start on the opening parentheses.
+	# Because the match_func_with_whitespace().get_end() is the index after the opening parentheses.
+	var closing_paren_index := get_closing_paren_index(opening_paren_index - 1, text)
 	if closing_paren_index == -1:
 		return ""
 
@@ -224,6 +226,8 @@ static func edit_vanilla_method(
 
 
 static func fix_method_super(method_name: String, func_def_end: int, text: String, regex_func_body: RegEx, regex_super_call: RegEx, offset := 0) -> String:
+	# Shift the func_def_end index back by one to start on the opening parentheses.
+	# Because the match_func_with_whitespace().get_end() is the index after the opening parentheses.
 	var closing_paren_index := get_closing_paren_index(func_def_end - 1, text)
 	if closing_paren_index == -1:
 		return text

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -224,7 +224,7 @@ static func edit_vanilla_method(
 
 
 static func fix_method_super(method_name: String, func_def_end: int, text: String, regex_func_body: RegEx, regex_super_call: RegEx, offset := 0) -> String:
-	var closing_paren_index := get_closing_paren_index(func_def_end, text)
+	var closing_paren_index := get_closing_paren_index(func_def_end - 1, text)
 	if closing_paren_index == -1:
 		return text
 	var func_body_start_index := text.find(":", closing_paren_index) +1


### PR DESCRIPTION
With the changes from #420, we need to start the search for `closing_paren_index` at `func_def_end - 1`.

But this needs a deeper look. based on my debugging, it seems there’s more wrong with how we’re processing that part.

<details><summary>Some print debugging</summary>
<p>

```
  text on func_def_end: ) ->
  method_name: _ready
  closing_paren_index: -1
  func_def_end: 83
  ---
  extends Portal
  
  
  @export var label_level_name_override := "New Game"
  
  
  func _ready() -> void:
      super()
      label_level_name.text = label_level_name_override
  
  
  func _on_hit_detector_body_entered(body: Node3D) -> void:
      super(body)
      Global.reset_game()
  
  No matching closing parenthesis
  text on func_def_end: body
  method_name: _on_hit_detector_body_entered
  closing_paren_index: -1
  func_def_end: 210
  ---
  extends Portal
  
  
  @export var label_level_name_override := "New Game"
  
  
  func vanilla_4007268940__ready() -> void:
      super()
      label_level_name.text = label_level_name_override
  
  
  func _on_hit_detector_body_entered(body: Node3D) -> void:
      super(body)
      Global.reset_game()
  
  No matching closing parenthesis
```

- I think `text on func_def_end` should always start with `)`. It looks like the result is shifted for the second method, and if this pattern continues, things will start to break again.


</p>
</details> 


For now, this should be enough to keep things moving.