### PR TITLE
feat: :sparkles: add `is_silent` to `process_script()`

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -36,9 +36,10 @@ func process_begin() -> void:
 	hashmap.clear()
 
 
-func process_script(path: String) -> String:
+func process_script(path: String, is_silent := false) -> String:
 	var start_time := Time.get_ticks_msec()
-	ModLoaderLog.debug("Start processing script at path: %s" % path, LOG_NAME)
+	if not is_silent:
+		ModLoaderLog.debug("Start processing script at path: %s" % path, LOG_NAME)
 	var current_script := load(path) as GDScript
 
 	var source_code := current_script.source_code
@@ -109,7 +110,8 @@ func process_script(path: String) -> String:
 	if source_code_additions != "":
 		source_code = "%s\n%s\n%s" % [source_code, MOD_LOADER_HOOKS_START_STRING, source_code_additions]
 
-	ModLoaderLog.debug("Finished processing script at path: %s in %s ms" % [path, Time.get_ticks_msec() - start_time], LOG_NAME)
+	if not is_silent:
+		ModLoaderLog.debug("Finished processing script at path: %s in %s ms" % [path, Time.get_ticks_msec() - start_time], LOG_NAME)
 
 	return source_code
 


### PR DESCRIPTION
This allows the Dev Tool to process scripts without errors.
- https://github.com/GodotModding/godot-mod-tool/pull/111#issuecomment-2475015380