### PR TITLE
test: :test_tube: Ported tests to 4.x

### DIFF
--- a/.github/actions/godot-install/action.yml
+++ b/.github/actions/godot-install/action.yml
@@ -19,11 +19,9 @@ inputs:
     type: string
     required: true
 
-
 runs:
   using: composite
   steps:
-
     - name: "Set Cache Name"
       shell: bash
       run: |

--- a/.github/actions/godot-install/action.yml
+++ b/.github/actions/godot-install/action.yml
@@ -1,0 +1,69 @@
+# Inspired by https://github.com/bitbrain/beehave/blob/godot-4.x/.github/actions/godot-install/action.yml
+
+name: install-godot-binary
+description: "Installs the Godot Runtime"
+
+inputs:
+  godot-version:
+    description: "The Godot engine version"
+    type: string
+    required: true
+  godot-status-version:
+    description: "The Godot engine status version"
+    type: string
+    required: true
+  godot-bin-name:
+    type: string
+    required: true
+  godot-cache-path:
+    type: string
+    required: true
+
+
+runs:
+  using: composite
+  steps:
+
+    - name: "Set Cache Name"
+      shell: bash
+      run: |
+        echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}" >> "$GITHUB_ENV"
+
+    - name: "Godot Cache Restore"
+      uses: actions/cache/restore@v3
+      id: godot-restore-cache
+      with:
+        path: ${{ inputs.godot-cache-path }}
+        key: ${{ env.CACHE_NAME }}
+
+    - name: "Download and Install Godot ${{ inputs.godot-version }}"
+      if: steps.godot-restore-cache.outputs.cache-hit != 'true'
+      continue-on-error: false
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.godot-cache-path }}
+        chmod 770 ${{ inputs.godot-cache-path }}
+        DIR="$HOME/.config/godot"
+        if [ ! -d "$DIR" ]; then
+          mkdir -p "$DIR"
+          chmod 770 "$DIR"
+        fi
+
+        DOWNLOAD_URL=https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}-${{ inputs.godot-status-version }}
+        GODOT_BIN=Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_${{ inputs.godot-bin-name }}
+
+        GODOT_PACKAGE=$GODOT_BIN.zip
+        wget $DOWNLOAD_URL/$GODOT_PACKAGE -P ${{ inputs.godot-cache-path }}
+        unzip ${{ inputs.godot-cache-path }}/$GODOT_PACKAGE -d ${{ inputs.godot-cache-path }}
+
+        mv ${{ inputs.godot-cache-path }}/$GODOT_BIN ${{ inputs.godot-cache-path }}/godot
+
+        chmod u+x ${{ inputs.godot-cache-path }}/godot
+        echo "${{ inputs.godot-cache-path }}/godot"
+
+    - name: "Godot Cache Save"
+      if: steps.godot-restore-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.godot-cache-path }}
+        key: ${{ steps.godot-restore-cache.outputs.cache-primary-key }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -67,8 +67,16 @@ runs:
       if: ${{ !cancelled() }}
       shell: bash
       run: ln -s ${{ github.workspace }}/addons/JSON_Schema_Validator ${{ github.workspace }}/test/addons/JSON_Schema_Validator
-
-    - name: "Run Tests"
+    - name: "🔄️ Run Import"
+      if: ${{ runner.OS == 'Linux'}} && ${{ !cancelled() }}
+      env:
+        TEST_PROJECT: ${{ inputs.godot-test-project }}
+      shell: bash
+      run: |
+        cd "${TEST_PROJECT}"
+        chmod +x run_import.sh
+        ./run_import.sh "$HOME/godot-linux/godot"
+    - name: "🧪 Run Tests"
       if: ${{ runner.OS == 'Linux'}} && ${{ !cancelled() }}
       env:
         TEST_PROJECT: ${{ inputs.godot-test-project }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: "Set Cache Name"
       shell: bash
       run: |
-        echo "CACHE_NAME_GUT=GUT_v7.4.1" >> "$GITHUB_ENV"
+        echo "CACHE_NAME_GUT=GUT_v9.3.0" >> "$GITHUB_ENV"
 
     - name: "GUT Cache Restore"
       uses: actions/cache/restore@v3
@@ -56,7 +56,7 @@ runs:
     - name: "⚔ Link GUT"
       if: ${{ !cancelled() }}
       shell: bash
-      run: ln -s ${{ inputs.gut-download-path }}/unzip/Gut-7.4.1/addons/gut ${{ github.workspace }}/test/addons/gut
+      run: ln -s ${{ inputs.gut-download-path }}/unzip/Gut-9.3.0/addons/gut ${{ github.workspace }}/test/addons/gut
 
     - name: "⚔ Link Mod Loader"
       if: ${{ !cancelled() }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,7 +39,7 @@ runs:
         chmod 770 ${{ inputs.gut-download-path }}
 
         wget https://github.com/bitwes/Gut/archive/refs/tags/v9.3.0.zip -P ${{ inputs.gut-download-path }}
-        unzip ${{ inputs.gut-download-path }}/v7.4.1.zip -d ${{ inputs.gut-download-path }}/unzip
+        unzip ${{ inputs.gut-download-path }}/v9.3.0.zip -d ${{ inputs.gut-download-path }}/unzip
 
     - name: "GUT Cache Save"
       if: steps.gut-restore-cache.outputs.cache-hit != 'true'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,79 @@
+# Inspired by https://github.com/utopia-rise/fmod-gdextension/blob/godot-3.x/demo/run_tests.sh
+
+name: test
+description: "Runs the tests via GUT CLI"
+
+inputs:
+  gut-download-path:
+    required: true
+    default: ~/gut_download
+  gut-addons-path:
+    required: true
+    default: ${{ github.workspace }}/test/addons/gut
+  godot-test-project:
+    required: true
+    default: ${{ github.workspace }}/test
+
+runs:
+  using: composite
+
+  steps:
+    - name: "Set Cache Name"
+      shell: bash
+      run: |
+        echo "CACHE_NAME_GUT=GUT_v7.4.1" >> "$GITHUB_ENV"
+
+    - name: "GUT Cache Restore"
+      uses: actions/cache/restore@v3
+      id: gut-restore-cache
+      with:
+        path: ${{ inputs.gut-download-path }}
+        key: ${{ runner.os }}-${{ env.CACHE_NAME_GUT }}
+
+    - name: "Download GUT"
+      if: steps.gut-restore-cache.outputs.cache-hit != 'true'
+      continue-on-error: false
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.gut-download-path }}
+        chmod 770 ${{ inputs.gut-download-path }}
+
+        wget https://github.com/bitwes/Gut/archive/refs/tags/v9.3.0.zip -P ${{ inputs.gut-download-path }}
+        unzip ${{ inputs.gut-download-path }}/v7.4.1.zip -d ${{ inputs.gut-download-path }}/unzip
+
+    - name: "GUT Cache Save"
+      if: steps.gut-restore-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.gut-download-path }}
+        key: ${{ steps.gut-restore-cache.outputs.cache-primary-key }}
+
+    - name: "Create addons Directory"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: mkdir -p ${{ github.workspace }}/test/addons
+
+    - name: "⚔ Link GUT"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: ln -s ${{ inputs.gut-download-path }}/unzip/Gut-7.4.1/addons/gut ${{ github.workspace }}/test/addons/gut
+
+    - name: "⚔ Link Mod Loader"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: ln -s ${{ github.workspace }}/addons/mod_loader ${{ github.workspace }}/test/addons/mod_loader
+
+    - name: "⚔ Link JSON_Schema_Validator"
+      if: ${{ !cancelled() }}
+      shell: bash
+      run: ln -s ${{ github.workspace }}/addons/JSON_Schema_Validator ${{ github.workspace }}/test/addons/JSON_Schema_Validator
+
+    - name: "Run Tests"
+      if: ${{ runner.OS == 'Linux'}} && ${{ !cancelled() }}
+      env:
+        TEST_PROJECT: ${{ inputs.godot-test-project }}
+      shell: bash
+      run: |
+        cd "${TEST_PROJECT}"
+        chmod +x run_tests.sh
+        ./run_tests.sh "$HOME/godot-linux/godot"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,27 @@
-on: [pull_request]
+# Inspired by https://github.com/bitbrain/beehave/blob/godot-4.x/.github/workflows/beehave-ci.yml
+
+name: Mod Loader CI
+
+on:
+  push:
+    paths-ignore:
+      - "**.jpg"
+      - "**.png"
+      - "**.svg"
+      - "**.md"
+      - "**plugin.cfg"
+  pull_request:
+    paths-ignore:
+      - "**.jpg"
+      - "**.png"
+      - "**.svg"
+      - "**.md"
+      - "**plugin.cfg"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
@@ -7,3 +30,8 @@ jobs:
       - uses: gregsdennis/dependencies-action@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  tests:
+    name: "Running GUT tests on Godot 4.3.0"
+    uses: ./.github/workflows/tests.yml
+    with:
+      godot-version: "4.3.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tests:
-    name: "Running GUT tests on Godot 4.3.0"
+    name: "Running GUT tests on Godot 4.3"
     uses: ./.github/workflows/tests.yml
     with:
-      godot-version: "4.3.0"
+      godot-version: "4.3"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,18 @@ on:
       os:
         required: false
         type: string
-        default: 'ubuntu-22.04'
+        default: "ubuntu-22.04"
       godot-version:
         required: true
         type: string
-        default: '4.3.0'
+        default: "4.3"
 
   workflow_dispatch:
     inputs:
       os:
         required: false
         type: string
-        default: 'ubuntu-22.04'
+        default: "ubuntu-22.04"
       godot-version:
         required: true
         type: string
@@ -40,15 +40,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: "🤖 Install Godot ${{ inputs.godot-version }}"
         uses: ./.github/actions/godot-install
         with:
           godot-version: ${{ inputs.godot-version }}
-          godot-status-version: 'stable'
-          godot-bin-name: 'linux_headless.64'
-          godot-cache-path: '~/godot-linux'
+          godot-status-version: "stable"
+          godot-bin-name: "linux.x86_64"
+          godot-cache-path: "~/godot-linux"
 
       - name: "🧪 Run Tests"
         if: ${{ !cancelled() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+# Inspired by https://github.com/bitbrain/beehave/blob/godot-4.x/.github/workflows/unit-tests.yml
+
+name: tests
+run-name: ${{ github.head_ref || github.ref_name }}-tests
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: 'ubuntu-22.04'
+      godot-version:
+        required: true
+        type: string
+        default: '4.3.0'
+
+  workflow_dispatch:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: 'ubuntu-22.04'
+      godot-version:
+        required: true
+        type: string
+
+concurrency:
+  group: tests-${{ github.head_ref || github.ref_name }}-${{ inputs.godot-version }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 15
+
+    steps:
+      - name: "📦 Checkout Mod Loader Repository"
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: 'recursive'
+
+      - name: "🤖 Install Godot ${{ inputs.godot-version }}"
+        uses: ./.github/actions/godot-install
+        with:
+          godot-version: ${{ inputs.godot-version }}
+          godot-status-version: 'stable'
+          godot-bin-name: 'linux_headless.64'
+          godot-cache-path: '~/godot-linux'
+
+      - name: "🧪 Run Tests"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 4
+        uses: ./.github/actions/test
+        with:
+          godot-test-project: ${{ github.workspace }}/test

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -234,7 +234,7 @@ func setup_file_data() -> void:
 	# if --main-pack cli arg is not set
 	file_name.pck = ModLoaderSetupUtils.get_file_name_from_path(path.exe, true, true)  if file_name.cli_arg_pck == '' else file_name.cli_arg_pck
 	# C:/path/to/game/game.pck
-	path.pck = path.game_base_dir.path_join(file_name.pck + '.pck')
+	path.pck = path.game_base_dir.plus_file(file_name.pck + '.pck')
 	# C:/path/to/game/addons/mod_loader/project.binary
 	path.project_binary = path.mod_loader_dir + "project.binary"
 

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -234,7 +234,7 @@ func setup_file_data() -> void:
 	# if --main-pack cli arg is not set
 	file_name.pck = ModLoaderSetupUtils.get_file_name_from_path(path.exe, true, true)  if file_name.cli_arg_pck == '' else file_name.cli_arg_pck
 	# C:/path/to/game/game.pck
-	path.pck = path.game_base_dir.plus_file(file_name.pck + '.pck')
+	path.pck = path.game_base_dir.path_join(file_name.pck + '.pck')
 	# C:/path/to/game/addons/mod_loader/project.binary
 	path.project_binary = path.mod_loader_dir + "project.binary"
 

--- a/addons/mod_loader/options/profiles/default.tres
+++ b/addons/mod_loader/options/profiles/default.tres
@@ -1,14 +1,24 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="ModLoaderOptionsProfile" load_steps=2 format=3 uid="uid://du84b0sewwguy"]
 
-[ext_resource path="res://addons/mod_loader/resources/options_profile.gd" type="Script" id=1]
-
+[ext_resource type="Script" path="res://addons/mod_loader/resources/options_profile.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 enable_mods = true
+locked_mods = Array[String]([])
+disabled_mods = Array[String]([])
+allow_modloader_autoloads_anywhere = false
 log_level = 3
-disabled_mods = [  ]
-steam_workshop_enabled = false
+ignore_deprecated_errors = false
+ignored_mod_names_in_log = Array[String]([])
+steam_id = 0
+semantic_version = "0.0.0"
+load_from_steam_workshop = false
+load_from_local = true
 override_path_to_mods = ""
 override_path_to_configs = ""
 override_path_to_workshop = ""
+override_path_to_hook_pack = ""
+override_hook_pack_name = ""
+restart_notification_scene_path = "res://addons/mod_loader/restart_notification.tscn"
+disable_restart = false

--- a/addons/mod_loader/options/profiles/default.tres
+++ b/addons/mod_loader/options/profiles/default.tres
@@ -1,24 +1,14 @@
-[gd_resource type="Resource" script_class="ModLoaderOptionsProfile" load_steps=2 format=3 uid="uid://du84b0sewwguy"]
+[gd_resource type="Resource" load_steps=2 format=2]
 
-[ext_resource type="Script" path="res://addons/mod_loader/resources/options_profile.gd" id="1"]
+[ext_resource path="res://addons/mod_loader/resources/options_profile.gd" type="Script" id=1]
+
 
 [resource]
-script = ExtResource("1")
+script = ExtResource( 1 )
 enable_mods = true
-locked_mods = Array[String]([])
-disabled_mods = Array[String]([])
-allow_modloader_autoloads_anywhere = false
 log_level = 3
-ignore_deprecated_errors = false
-ignored_mod_names_in_log = Array[String]([])
-steam_id = 0
-semantic_version = "0.0.0"
-load_from_steam_workshop = false
-load_from_local = true
+disabled_mods = [  ]
+steam_workshop_enabled = false
 override_path_to_mods = ""
 override_path_to_configs = ""
 override_path_to_workshop = ""
-override_path_to_hook_pack = ""
-override_hook_pack_name = ""
-restart_notification_scene_path = "res://addons/mod_loader/restart_notification.tscn"
-disable_restart = false

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,11 @@
+.godot/
+*.import
+addons/
+icon.png
+
+# Gut stuff in root dir
+asset_lib_icon.png
+gut_panel.png
+.gut_editor_shortcuts.cfg
+BigFont.tres
+BigFontTheme.tres

--- a/test/.gutconfig.json
+++ b/test/.gutconfig.json
@@ -1,0 +1,16 @@
+{
+  "dirs":["res://Unit/"],
+  "double_strategy":"partial",
+  "ignore_pause":false,
+  "include_subdirs":true,
+  "inner_class":"",
+  "log_level":3,
+  "opacity":100,
+  "prefix":"test_",
+  "selected":"",
+  "should_exit":true,
+  "should_maximize":true,
+  "suffix":".gd",
+  "tests":[],
+  "unit_test_name":""
+}

--- a/test/TestRunner.tscn
+++ b/test/TestRunner.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=3 uid="uid://dkea2wjvdowwf"]
+
+[node name="TestRunner" type="Control"]
+custom_minimum_size = Vector2(740, 250)
+layout_mode = 3
+anchors_preset = 0
+offset_right = 740.0
+offset_bottom = 250.0

--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -35,10 +35,10 @@ func test_get_closing_paren_index(params: Array = use_parameters(test_get_closin
 
 
 var test_match_func_with_whitespace_params = [
-	["abc", FUNCTIONS_SAMPLE1, 0, ["func abc(", 0, 9]],
-	["test", FUNCTIONS_SAMPLE1, 0, ["func test(", 19, 29]],
-	["_ready", FUNCTIONS_SAMPLE2, 0, ["func _ready(", 70, 82]],
-	["_on_hit_detector_body_entered", FUNCTIONS_SAMPLE2, 0, ["func _on_hit_detector_body_entered(", 155, 190]],
+	["abc", FUNCTIONS_SAMPLE1, 0, ["func abc("]],
+	["test", FUNCTIONS_SAMPLE1, 0, ["func test("]],
+	["_ready", FUNCTIONS_SAMPLE2, 0, ["func _ready("]],
+	["_on_hit_detector_body_entered", FUNCTIONS_SAMPLE2, 0, ["func _on_hit_detector_body_entered("]],
 ]
 
 const FUNCTIONS_SAMPLE1 := """\
@@ -69,6 +69,8 @@ func _on_hit_detector_body_entered(body: Node3D) -> void:
 	Global.reset_game()
 """
 
+
+# We can't (easily) test for start and end indices due to different line endings between Windows and Linux.
 func test_match_func_with_whitespace(params: Array = use_parameters(test_match_func_with_whitespace_params)) -> void:
 	# prepare
 	var method_name: String = params[0]
@@ -76,8 +78,6 @@ func test_match_func_with_whitespace(params: Array = use_parameters(test_match_f
 	var offset: int  = params[2]
 
 	var expected_string: String = params.back()[0]
-	var expected_start: int = params.back()[1]
-	var expected_end: int = params.back()[2]
 
 	# test
 	var result := _ModLoaderModHookPreProcessor.match_func_with_whitespace(method_name, text, offset)
@@ -88,12 +88,4 @@ func test_match_func_with_whitespace(params: Array = use_parameters(test_match_f
 	assert_eq(
 		result.get_string(), expected_string,
 		"expected %s, got %s" % [expected_string, result.get_string()]
-	)
-	assert_eq(
-		result.get_start(), expected_start,
-		"expected %s, got %s" % [expected_start, result.get_start()]
-	)
-	assert_eq(
-		result.get_end(), expected_end,
-		"expected %s, got %s" % [expected_end, result.get_end()]
 	)

--- a/test/Unit/test_script_extension_sorting.gd
+++ b/test/Unit/test_script_extension_sorting.gd
@@ -8,6 +8,7 @@ extends GutTest
 #	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd"
 #]
 
+# https://github.com/GodotModding/godot-mod-loader/pull/357
 var order_after_357_correct := [
 	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd",
 	"res://mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd",

--- a/test/Unit/test_script_extension_sorting.gd
+++ b/test/Unit/test_script_extension_sorting.gd
@@ -1,0 +1,29 @@
+extends GutTest
+
+
+#var order_before_357_correct := [
+#	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd",
+#	"res://mods-unpacked/test-mod2/extensions/script_extension_sorting/script_c.gd",
+#	"res://mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd",
+#	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd"
+#]
+
+var order_after_357_correct := [
+	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd",
+	"res://mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd",
+	"res://mods-unpacked/test-mod2/extensions/script_extension_sorting/script_c.gd",
+	"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd"
+]
+
+
+func test_handle_script_extensions():
+	var extension_paths := [
+		"res://mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd",
+		"res://mods-unpacked/test-mod2/extensions/script_extension_sorting/script_c.gd",
+		"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd",
+		"res://mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd"
+	]
+
+	_ModLoaderScriptExtension.InheritanceSorting.new(extension_paths)
+
+	assert_true(extension_paths == order_after_357_correct, "Expected %s but was %s instead" % [JSON.stringify(order_after_357_correct, "\t"), JSON.stringify(extension_paths, "\t")])

--- a/test/default_env.tres
+++ b/test/default_env.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://dhpbuhssb7uh"]
+
+[sub_resource type="Sky" id="1"]
+
+[resource]
+background_mode = 2
+sky = SubResource("1")

--- a/test/mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd
+++ b/test/mods-unpacked/test-mod1/extensions/script_extension_sorting/script_c.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_c.gd"

--- a/test/mods-unpacked/test-mod1/manifest.json
+++ b/test/mods-unpacked/test-mod1/manifest.json
@@ -1,0 +1,40 @@
+{
+	"name": "mod1",
+	"namespace": "test",
+	"version_number": "0.0.1",
+	"description": "Description of your mod...",
+	"website_url": "https://github.com/exampleauthor/examplemod",
+	"dependencies": [
+
+	],
+	"extra": {
+		"godot": {
+			"authors": [
+				"AuthorName"
+			],
+			"optional_dependencies": [
+
+			],
+			"compatible_game_version": [
+				"0.0.1"
+			],
+			"compatible_mod_loader_version": [
+				"6.1.0"
+			],
+			"incompatibilities": [
+
+			],
+			"load_before": [
+
+			],
+			"tags": [
+
+			],
+			"config_schema": {
+
+			},
+			"description_rich": "",
+			"image": null
+		}
+	}
+}

--- a/test/mods-unpacked/test-mod1/mod_main.gd
+++ b/test/mods-unpacked/test-mod1/mod_main.gd
@@ -1,0 +1,31 @@
+extends Node
+
+
+const TEST_MOD1_DIR := "test-mod1"
+const TEST_MOD1_LOG_NAME := "test-mod1:Main"
+
+var mod_dir_path := ""
+var extensions_dir_path := ""
+var translations_dir_path := ""
+
+
+func _init() -> void:
+	mod_dir_path = ModLoaderMod.get_unpacked_dir().path_join(TEST_MOD1_DIR)
+	# Add extensions
+	install_script_extensions()
+	# Add translations
+	add_translations()
+
+
+func install_script_extensions() -> void:
+	extensions_dir_path = mod_dir_path.path_join("extensions")
+	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
+
+
+
+func add_translations() -> void:
+	translations_dir_path = mod_dir_path.path_join("translations")
+
+
+func _ready() -> void:
+	pass

--- a/test/mods-unpacked/test-mod1/mod_main.gd
+++ b/test/mods-unpacked/test-mod1/mod_main.gd
@@ -17,10 +17,13 @@ func _init() -> void:
 	add_translations()
 
 
+# `install_script_extension` is commented out to prevent interference
+# with the script extension sorting test. Applying script extensions
+# causes the `.get_base_script()` call in `_ModLoaderScriptExtension.InheritanceSorting`
+# to return an incorrect value.
 func install_script_extensions() -> void:
 	extensions_dir_path = mod_dir_path.path_join("extensions")
-	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
-
+	#ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
 
 
 func add_translations() -> void:

--- a/test/mods-unpacked/test-mod2/extensions/script_extension_sorting/script_c.gd
+++ b/test/mods-unpacked/test-mod2/extensions/script_extension_sorting/script_c.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_c.gd"

--- a/test/mods-unpacked/test-mod2/manifest.json
+++ b/test/mods-unpacked/test-mod2/manifest.json
@@ -1,0 +1,40 @@
+{
+	"name": "mod2",
+	"namespace": "test",
+	"version_number": "0.0.1",
+	"description": "Description of your mod...",
+	"website_url": "https://github.com/exampleauthor/examplemod",
+	"dependencies": [
+		"test-mod1"
+	],
+	"extra": {
+		"godot": {
+			"authors": [
+				"AuthorName"
+			],
+			"optional_dependencies": [
+
+			],
+			"compatible_game_version": [
+				"0.0.1"
+			],
+			"compatible_mod_loader_version": [
+				"6.1.0"
+			],
+			"incompatibilities": [
+
+			],
+			"load_before": [
+
+			],
+			"tags": [
+
+			],
+			"config_schema": {
+
+			},
+			"description_rich": "",
+			"image": null
+		}
+	}
+}

--- a/test/mods-unpacked/test-mod2/mod_main.gd
+++ b/test/mods-unpacked/test-mod2/mod_main.gd
@@ -1,0 +1,31 @@
+extends Node
+
+
+const TEST_MOD2_DIR := "test-mod2"
+const TEST_MOD2_LOG_NAME := "test-mod2:Main"
+
+var mod_dir_path := ""
+var extensions_dir_path := ""
+var translations_dir_path := ""
+
+
+func _init() -> void:
+	mod_dir_path = ModLoaderMod.get_unpacked_dir().path_join(TEST_MOD2_DIR)
+	# Add extensions
+	install_script_extensions()
+	# Add translations
+	add_translations()
+
+
+func install_script_extensions() -> void:
+	extensions_dir_path = mod_dir_path.path_join("extensions")
+	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
+
+
+
+func add_translations() -> void:
+	translations_dir_path = mod_dir_path.path_join("translations")
+
+
+func _ready() -> void:
+	pass

--- a/test/mods-unpacked/test-mod2/mod_main.gd
+++ b/test/mods-unpacked/test-mod2/mod_main.gd
@@ -17,10 +17,13 @@ func _init() -> void:
 	add_translations()
 
 
+# `install_script_extension` is commented out to prevent interference
+# with the script extension sorting test. Applying script extensions
+# causes the `.get_base_script()` call in `_ModLoaderScriptExtension.InheritanceSorting`
+# to return an incorrect value.
 func install_script_extensions() -> void:
 	extensions_dir_path = mod_dir_path.path_join("extensions")
-	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
-
+	#ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_c.gd"))
 
 
 func add_translations() -> void:

--- a/test/mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd
+++ b/test/mods-unpacked/test-mod3/extensions/script_extension_sorting/script_b.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_b.gd"

--- a/test/mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd
+++ b/test/mods-unpacked/test-mod3/extensions/script_extension_sorting/script_d.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_d.gd"

--- a/test/mods-unpacked/test-mod3/manifest.json
+++ b/test/mods-unpacked/test-mod3/manifest.json
@@ -1,0 +1,40 @@
+{
+	"name": "mod3",
+	"namespace": "test",
+	"version_number": "0.0.1",
+	"description": "Description of your mod...",
+	"website_url": "https://github.com/exampleauthor/examplemod",
+	"dependencies": [
+
+	],
+	"extra": {
+		"godot": {
+			"authors": [
+				"AuthorName"
+			],
+			"optional_dependencies": [
+
+			],
+			"compatible_game_version": [
+				"0.0.1"
+			],
+			"compatible_mod_loader_version": [
+				"6.1.0"
+			],
+			"incompatibilities": [
+
+			],
+			"load_before": [
+
+			],
+			"tags": [
+
+			],
+			"config_schema": {
+
+			},
+			"description_rich": "",
+			"image": null
+		}
+	}
+}

--- a/test/mods-unpacked/test-mod3/mod_main.gd
+++ b/test/mods-unpacked/test-mod3/mod_main.gd
@@ -1,0 +1,31 @@
+extends Node
+
+
+const TEST_MOD3_DIR := "test-mod3"
+const TEST_MOD3_LOG_NAME := "test-mod3:Main"
+
+var mod_dir_path := ""
+var extensions_dir_path := ""
+var translations_dir_path := ""
+
+
+func _init() -> void:
+	mod_dir_path = ModLoaderMod.get_unpacked_dir().path_join(TEST_MOD3_DIR)
+	# Add extensions
+	install_script_extensions()
+	# Add translations
+	add_translations()
+
+
+func install_script_extensions() -> void:
+	extensions_dir_path = mod_dir_path.path_join("extensions")
+	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_b.gd"))
+	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_d.gd"))
+
+
+func add_translations() -> void:
+	translations_dir_path = mod_dir_path.path_join("translations")
+
+
+func _ready() -> void:
+	pass

--- a/test/mods-unpacked/test-mod3/mod_main.gd
+++ b/test/mods-unpacked/test-mod3/mod_main.gd
@@ -17,10 +17,14 @@ func _init() -> void:
 	add_translations()
 
 
+# `install_script_extension` is commented out to prevent interference
+# with the script extension sorting test. Applying script extensions
+# causes the `.get_base_script()` call in `_ModLoaderScriptExtension.InheritanceSorting`
+# to return an incorrect value.
 func install_script_extensions() -> void:
 	extensions_dir_path = mod_dir_path.path_join("extensions")
-	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_b.gd"))
-	ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_d.gd"))
+	#ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_b.gd"))
+	#ModLoaderMod.install_script_extension(extensions_dir_path.path_join("script_extension_sorting/script_d.gd"))
 
 
 func add_translations() -> void:

--- a/test/project.godot
+++ b/test/project.godot
@@ -1,0 +1,37 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Godot Mod Loader Test"
+run/main_scene="res://TestRunner.tscn"
+config/features=PackedStringArray("4.3")
+config/icon="res://icon.png"
+
+[autoload]
+
+ModLoaderStore="*res://addons/mod_loader/mod_loader_store.gd"
+ModLoader="*res://addons/mod_loader/mod_loader.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gut/plugin.cfg")
+
+[gui]
+
+common/drop_mouse_on_gui_input_disabled=true
+
+[physics]
+
+common/enable_pause_aware_picking=true
+
+[rendering]
+
+environment/defaults/default_environment="res://default_env.tres"

--- a/test/run_import.sh
+++ b/test/run_import.sh
@@ -1,0 +1,1 @@
+$1 --import --headless --path $PWD

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,1 @@
+$1 -d -s --path $PWD addons/gut/gut_cmdln.gd

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,1 +1,1 @@
-$1 -d -s --path $PWD addons/gut/gut_cmdln.gd
+$1 -d -s --headless --path $PWD addons/gut/gut_cmdln.gd

--- a/test/script_extension_sorting/script_a.gd
+++ b/test/script_extension_sorting/script_a.gd
@@ -1,0 +1,1 @@
+extends Node

--- a/test/script_extension_sorting/script_b.gd
+++ b/test/script_extension_sorting/script_b.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_a.gd"

--- a/test/script_extension_sorting/script_c.gd
+++ b/test/script_extension_sorting/script_c.gd
@@ -1,0 +1,1 @@
+extends "res://script_extension_sorting/script_b.gd"

--- a/test/script_extension_sorting/script_d.gd
+++ b/test/script_extension_sorting/script_d.gd
@@ -1,0 +1,1 @@
+extends Node


### PR DESCRIPTION
Ported the test workflow from the 3.x branch  

## Notable Changes  
- Updated the GUT version to the [latest release v9.3.0](https://github.com/bitwes/Gut/releases/tag/v9.3.0)  
- Updated the Godot version:  
  - Currently running tests only on 4.3  
  - No separate headless version, now using `--headless` instead  
  - Global class data is no longer stored in the project file, requiring a `--import` run before tests are executed  

## To-Do  
- [ ] Run tests on additional Godot versions:  
  - [ ] 4.2.2  
  - [ ] 4.1.4  
- [x] Resolve two currently failing tests:  
  - [x] `test_match_func_with_whitespace`  
  - [x] `test_handle_script_extensions`  