### PR TITLE
fix: hooks argument order, hook check

### DIFF
--- a/addons/mod_loader/internal/hooks.gd
+++ b/addons/mod_loader/internal/hooks.gd
@@ -21,11 +21,13 @@ static func add_hook(mod_callable: Callable, script_path: String, method_name: S
 		ModLoaderStore.hooked_script_paths[script_path] = true
 
 
-static func call_hooks(self_object: Object, args: Array, hook_hash:int) -> void:
+static func call_hooks(self_object: Object, args: Array, hook_hash: int) -> void:
 	var hooks = ModLoaderStore.modding_hooks.get(hook_hash, null)
-	if hooks:
-		for mod_func: Callable in hooks:
-			mod_func.bind(self_object).callv(args)
+	if not hooks:
+		return
+
+	for mod_func: Callable in hooks:
+		mod_func.callv([self_object] + args)
 
 
 static func get_hook_hash(path:String, method:String, is_before:bool) -> int:

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -281,7 +281,7 @@ static func get_mod_loader_hook(
 
 	return """
 {STATIC}func {METHOD_NAME}({METHOD_PARAMS}){RETURN_TYPE_STRING}:
-	{HOOKS_CHECK}_ModLoaderHooks.call_hooks({SELF}, [{METHOD_ARGS}], {HOOK_ID_BEFORE})
+	{HOOK_CHECK}_ModLoaderHooks.call_hooks({SELF}, [{METHOD_ARGS}], {HOOK_ID_BEFORE})
 	{METHOD_RETURN_VAR}{METHOD_PREFIX}_{METHOD_NAME}({METHOD_ARGS})
 	{HOOK_CHECK}_ModLoaderHooks.call_hooks({SELF}, [{METHOD_ARGS}], {HOOK_ID_AFTER})
 	{METHOD_RETURN}""".format({


### PR DESCRIPTION
- fixes a typo that slipped into the hook gen
- changes the hook order from the less intuitive `arg, arg2, self_object` to `self_object, arg, arg2`
- also improves performance since .bind is slow apparently

<details>
<summary>Profiling code</summary>

```gdscript
extends Node

var mod_func = func(self_object, arg1, arg2): 
    	self_object.text = arg2
        var t := [arg1, arg2, self_object.text, self_object]
        #print(t)
            
var mod_func2 = func(arg1, arg2, self_object): 
    	self_object.text = arg2
        var t := [arg1, arg2, self_object.text, self_object]
        #print(t)
        

func _ready():
    var args := ["hello", "world"]
    var self_object := Label.new()
    var count := 100_000
        
    var t1 := []
    var t2 := []
    var t3 := []
    
    for f in 5:
        var start_time := Time.get_ticks_msec()
        for i in count:
            mod_func.callv([self_object] + args)
        var end_time := Time.get_ticks_msec() - start_time
        printt("Finished in %s ms" % end_time, ".callv([self_object] + args)")
        t1.append(end_time)

        var start_time2 := Time.get_ticks_msec()
        for i in count:
            mod_func2.bind(self_object).callv(args)
        var end_time2 := Time.get_ticks_msec() - start_time
        printt("Finished in %s ms" % end_time2, ".bind(self_object).callv(args)")
        t2.append(end_time2)
        
    	var start_time3 := Time.get_ticks_msec()
        for i in count:
            mod_func.mod_func.callv([self_object] + args)
        var end_time3 := Time.get_ticks_msec() - start_time
        printt("Finished in %s ms" % end_time3, ".bindv(args).bind(self_object).call()")
        t3.append(end_time3)
        print("---")

    stats(t1, ".callv([self_object] + args)")
    stats(t2, ".bind(self_object).callv(args)")
    stats(t3, ".bindv(args).bind(self_object).call()")

    pass

func stats(arr, thing):
    printt("min", arr.min(), "max", arr.max(), "avg", arr.reduce(sum, 0)/arr.size(), thing)

func sum(accum, number):
    return accum + number
```

```
min    77      max    82      avg    78      .callv([self_object] + args)
min    141    max    147    avg    143    .bind(self_object).callv(args)
min    224    max    233    avg    228    .bindv(args).bind(self_object).call()
```

</details>