### PR TITLE
feat: :sparkles: support async hooks for methods using await

### DIFF
--- a/addons/mod_loader/api/hook_chain.gd
+++ b/addons/mod_loader/api/hook_chain.gd
@@ -1,0 +1,73 @@
+class_name ModLoaderHookChain
+extends RefCounted
+## Small class to keep the state of hook execution chains and move between mod hook calls.[br]
+## For examples, see [method ModLoaderMod.add_hook].
+
+
+## The reference object is usually the [Node] that the vanilla script is attached to. [br]
+## If the hooked method is [code]static[/code], it will contain the [GDScript] itself.
+var reference_object: Object
+
+var _callbacks: Array[Callable] = []
+var _callback_index := -1
+
+
+const LOG_NAME := "ModLoaderHookChain"
+
+
+func _init(reference_object: Object, callbacks: Array[Callable]) -> void:
+	self.reference_object = reference_object
+	_callbacks.assign(callbacks)
+	_callback_index = callbacks.size()
+
+
+## Will execute the next mod hook callable or vanilla method and return the result.[br]
+## Make sure to call this method [i][color=orange]once[/color][/i] somewhere in the [param mod_callable] you pass to [method ModLoaderMod.add_hook]. [br]
+##
+## [br][b]Parameters:[/b][br]
+## - [param args] ([Array]): An array of all arguments passed into the vanilla function. [br]
+##
+## [br][b]Returns:[/b] [Variant][br][br]
+func execute_next(args := []) -> Variant:
+	var callback := next_callback()
+
+	# Vanilla needs to be called without the hook chain being passed
+	if is_vanilla():
+		return callback.callv(args)
+
+	return callback.callv([self] + args)
+
+
+## Same as [method execute_next], but asynchronous - it can be used with [code]await[/code]. [br]
+## This hook needs to be used if the vanilla method uses [code]await[/code] somewhere. [br]
+## Make sure to call this method [i][color=orange]once[/color][/i] somewhere in the [param mod_callable] you pass to [method ModLoaderMod.add_hook]. [br]
+##
+## [br][b]Parameters:[/b][br]
+## - [param args] ([Array]): An array of all arguments passed into the vanilla function. [br]
+##
+## [br][b]Returns:[/b] [Variant][br][br]
+func execute_next_async(args := []) -> Variant:
+	var callback := next_callback()
+
+	# Vanilla needs to be called without the hook chain being passed
+	if is_vanilla():
+		return await callback.callv(args)
+
+	return await callback.callv([self] + args)
+
+
+func next_callback() -> Variant:
+	_callback_index -= 1
+	if not _callback_index >= 0:
+		ModLoaderLog.fatal(
+			"The hook chain index should never be negative. " +
+			"A mod hook has called execute_next twice or ModLoaderHookChain was modified in an unsupported way.",
+			LOG_NAME
+		)
+		return
+
+	return _callbacks[_callback_index]
+
+
+func is_vanilla() -> bool:
+	return _callback_index == 0


### PR DESCRIPTION
ref https://github.com/GodotModding/godot-mod-loader/pull/436#issuecomment-2488742592

this allows using async stuff in mod hooks and applying hooks to async methods. issue being that the preprocessor needs to hook these differently and for that we need to discern if something is actually async/using await/being called with await and inserting a different hook in those cases..

```gdscript
return await _ModLoaderHooks.call_hooks_async(vanilla_1539570981_async_test_method, [param], 2690100866)
```

if we can't do it automagically, we can let the user decide it by adding `ModLoaderMod.add_async_hook()` or something similar.. but that would knock out the export plugin for the time being (though the game dev could also just add markers there like @unmoddable we have?)


we definitely want per-method hook gen
- #426

