### PR TITLE
feat: :sparkles: support async hooks for methods using await

### DIFF
--- a/addons/mod_loader/api/hook_chain.gd
+++ b/addons/mod_loader/api/hook_chain.gd
@@ -31,9 +31,36 @@ func _init(reference_object: Object, callbacks: Array) -> void:
 ##
 ## [br][b]Returns:[/b] [Variant][br][br]
 func execute_next(args := []) -> Variant:
-	_callback_index -= 1
+	var callback := next_callback()
 
-	if _callback_index < 0:
+	# Vanilla needs to be called without the hook chain being passed
+	if is_vanilla():
+		return callback.callv(args)
+
+	return callback.callv([self] + args)
+
+
+## Same as [method execute_next], but asynchronous - it can be used with [code]await[/code]. [br]
+## This hook needs to be used if the vanilla method uses [code]await[/code] somewhere. [br]
+## Make sure to call this method [i][color=orange]once[/color][/i] somewhere in the [param mod_callable] you pass to [method ModLoaderMod.add_hook]. [br]
+##
+## [br][b]Parameters:[/b][br]
+## - [param args] ([Array]): An array of all arguments passed into the vanilla function. [br]
+##
+## [br][b]Returns:[/b] [Variant][br][br]
+func execute_next_async(args := []) -> Variant:
+	var callback := next_callback()
+
+	# Vanilla needs to be called without the hook chain being passed
+	if is_vanilla():
+		return await callback.callv(args)
+
+	return await callback.callv([self] + args)
+
+
+func next_callback() -> Variant:
+	_callback_index -= 1
+	if not _callback_index >= 0:
 		ModLoaderLog.fatal(
 			"The hook chain index should never be negative. " +
 			"A mod hook has called execute_next twice or ModLoaderHookChain was modified in an unsupported way.",
@@ -41,10 +68,8 @@ func execute_next(args := []) -> Variant:
 		)
 		return
 
-	var callback :=  _callbacks[_callback_index]
+	return _callbacks[_callback_index]
 
-	# Vanilla call is always at index 0 and needs to be called without the hook chain being passed
-	if _callback_index == 0:
-		return callback.callv(args)
 
-	return callback.callv([self] + args)
+func is_vanilla() -> bool:
+	return _callback_index == 0

--- a/addons/mod_loader/api/hook_chain.gd
+++ b/addons/mod_loader/api/hook_chain.gd
@@ -31,16 +31,18 @@ func _init(reference_object: Object, callbacks: Array) -> void:
 ##
 ## [br][b]Returns:[/b] [Variant][br][br]
 func execute_next(args := []) -> Variant:
-	var callback := next_callback()
+	var callback := _get_next_callback()
+	if not callback:
+		return
 
 	# Vanilla needs to be called without the hook chain being passed
-	if is_vanilla():
+	if _is_callback_vanilla():
 		return callback.callv(args)
 
 	return callback.callv([self] + args)
 
 
-## Same as [method execute_next], but asynchronous - it can be used with [code]await[/code]. [br]
+## Same as [method execute_next], but asynchronous - it can be used if a method uses [code]await[/code]. [br]
 ## This hook needs to be used if the vanilla method uses [code]await[/code] somewhere. [br]
 ## Make sure to call this method [i][color=orange]once[/color][/i] somewhere in the [param mod_callable] you pass to [method ModLoaderMod.add_hook]. [br]
 ##
@@ -49,16 +51,18 @@ func execute_next(args := []) -> Variant:
 ##
 ## [br][b]Returns:[/b] [Variant][br][br]
 func execute_next_async(args := []) -> Variant:
-	var callback := next_callback()
+	var callback := _get_next_callback()
+	if not callback:
+		return
 
 	# Vanilla needs to be called without the hook chain being passed
-	if is_vanilla():
+	if _is_callback_vanilla():
 		return await callback.callv(args)
 
 	return await callback.callv([self] + args)
 
 
-func next_callback() -> Variant:
+func _get_next_callback() -> Variant:
 	_callback_index -= 1
 	if not _callback_index >= 0:
 		ModLoaderLog.fatal(
@@ -71,5 +75,5 @@ func next_callback() -> Variant:
 	return _callbacks[_callback_index]
 
 
-func is_vanilla() -> bool:
+func _is_callback_vanilla() -> bool:
 	return _callback_index == 0

--- a/addons/mod_loader/internal/hooks.gd
+++ b/addons/mod_loader/internal/hooks.gd
@@ -11,8 +11,7 @@ const LOG_NAME := "ModLoader:Hooks"
 ## To add hooks from a mod use [method ModLoaderMod.add_hook].
 static func add_hook(mod_callable: Callable, script_path: String, method_name: String) -> void:
 	ModLoaderStore.any_mod_hooked = true
-	var hash = get_hook_hash(script_path, method_name)
-
+	var hash := get_hook_hash(script_path, method_name)
 	if not ModLoaderStore.modding_hooks.has(hash):
 		ModLoaderStore.modding_hooks[hash] = []
 	ModLoaderStore.modding_hooks[hash].push_back(mod_callable)
@@ -29,11 +28,17 @@ static func call_hooks(vanilla_method: Callable, args: Array, hook_hash: int) ->
 	if hooks.is_empty():
 		return vanilla_method.callv(args)
 
-	# Create a hook chain which will call down until the vanilla method is reached
-	var callbacks = [vanilla_method]
-	callbacks.append_array(hooks)
-	var chain := ModLoaderHookChain.new(vanilla_method.get_object(), callbacks)
+	var chain := ModLoaderHookChain.new(vanilla_method.get_object(), [vanilla_method] + hooks)
 	return chain.execute_next(args)
+
+
+static func call_hooks_async(vanilla_method: Callable, args: Array, hook_hash: int) -> Variant:
+	var hooks: Array = ModLoaderStore.modding_hooks.get(hook_hash, [])
+	if hooks.is_empty():
+		return await vanilla_method.callv(args)
+
+	var chain := ModLoaderHookChain.new(vanilla_method.get_object(), [vanilla_method] + hooks)
+	return await chain.async_execute_next(args)
 
 
 static func get_hook_hash(path: String, method: String) -> int:

--- a/addons/mod_loader/internal/hooks.gd
+++ b/addons/mod_loader/internal/hooks.gd
@@ -38,7 +38,7 @@ static func call_hooks_async(vanilla_method: Callable, args: Array, hook_hash: i
 		return await vanilla_method.callv(args)
 
 	var chain := ModLoaderHookChain.new(vanilla_method.get_object(), [vanilla_method] + hooks)
-	return await chain.async_execute_next(args)
+	return await chain.execute_next_async(args)
 
 
 static func get_hook_hash(path: String, method: String) -> int:


### PR DESCRIPTION
clone of #458

Test Project: 
[project.zip](https://github.com/user-attachments/files/17951341/project.zip)


> ref https://github.com/GodotModding/godot-mod-loader/pull/436#issuecomment-2488742592
> 
> this allows using async stuff in mod hooks and applying hooks to async methods. issue being that the preprocessor needs to hook these differently and for that we need to discern if something is actually async/using await/being called with await and inserting a different hook in those cases..
> 
> ```gdscript
> return await _ModLoaderHooks.call_hooks_async(vanilla_1539570981_async_test_method, [param], 2690100866)
> ```
> 
> if we can't do it automagically, we can let the user decide it by adding `ModLoaderMod.add_async_hook()` or something similar.. but that would knock out the export plugin for the time being (though the game dev could also just add markers there like @unmoddable we have?)
> 
> 
> we definitely want per-method hook gen
> - #426

