### PR TITLE
test: :test_tube: added tests for `.process_script()`

### DIFF
--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -95,9 +95,9 @@ func test_process_script() -> void:
 	var hook_pre_processor := _ModLoaderModHookPreProcessor.new()
 	hook_pre_processor.process_begin()
 
-	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd")
+	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd", false)
 	var result_a_expected: String = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd").source_code.trim_prefix("#")
-	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd")
+	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd", false)
 	var result_b_expected: String = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd").source_code.trim_prefix("#")
 	var result_c := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_C.gd")
 	var result_c_expected: String = load("res://test_mod_hook_preprocessor/test_script_C_processed.gd").source_code.trim_prefix("#")

--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -89,3 +89,19 @@ func test_match_func_with_whitespace(params: Array = use_parameters(test_match_f
 		result.get_string(), expected_string,
 		"expected %s, got %s" % [expected_string, result.get_string()]
 	)
+
+
+func test_process_script() -> void:
+	var hook_pre_processor := _ModLoaderModHookPreProcessor.new()
+	hook_pre_processor.process_begin()
+
+	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd")
+	var result_a_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd")
+	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd")
+	var result_b_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd")
+	var result_c := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_C.gd")
+	var result_c_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_C_processed.gd")
+
+	assert_eq(result_a, result_a_expected.source_code.trim_prefix("#"))
+	assert_eq(result_b, result_b_expected.source_code.trim_prefix("#"))
+	assert_eq(result_c, result_c_expected.source_code.trim_prefix("#"))

--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -96,12 +96,12 @@ func test_process_script() -> void:
 	hook_pre_processor.process_begin()
 
 	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd")
-	var result_a_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd")
+	var result_a_expected: String = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd").source_code.trim_prefix("#")
 	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd")
-	var result_b_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd")
+	var result_b_expected: String = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd").source_code.trim_prefix("#")
 	var result_c := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_C.gd")
-	var result_c_expected: GDScript = load("res://test_mod_hook_preprocessor/test_script_C_processed.gd")
+	var result_c_expected: String = load("res://test_mod_hook_preprocessor/test_script_C_processed.gd").source_code.trim_prefix("#")
 
-	assert_eq(result_a, result_a_expected.source_code.trim_prefix("#"))
-	assert_eq(result_b, result_b_expected.source_code.trim_prefix("#"))
-	assert_eq(result_c, result_c_expected.source_code.trim_prefix("#"))
+	assert_eq(result_a, result_a_expected)
+	assert_eq(result_b, result_b_expected)
+	assert_eq(result_c, result_c_expected)

--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -95,11 +95,11 @@ func test_process_script() -> void:
 	var hook_pre_processor := _ModLoaderModHookPreProcessor.new()
 	hook_pre_processor.process_begin()
 
-	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd", false)
+	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd")
 	var result_a_expected: String = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd").source_code.trim_prefix("#")
-	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd", false)
+	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd")
 	var result_b_expected: String = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd").source_code.trim_prefix("#")
-	var result_c := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_C.gd")
+	var result_c := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_C.gd", true)
 	var result_c_expected: String = load("res://test_mod_hook_preprocessor/test_script_C_processed.gd").source_code.trim_prefix("#")
 
 	assert_eq(result_a, result_a_expected)

--- a/test/Unit/test_mod_hook_preprocessor.gd
+++ b/test/Unit/test_mod_hook_preprocessor.gd
@@ -96,6 +96,7 @@ func test_process_script() -> void:
 	hook_pre_processor.process_begin()
 
 	var result_a := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_A.gd")
+	# Using source_code.trim_prefix("#") to prevent hiding global class error.
 	var result_a_expected: String = load("res://test_mod_hook_preprocessor/test_script_A_processed.gd").source_code.trim_prefix("#")
 	var result_b := hook_pre_processor.process_script("res://test_mod_hook_preprocessor/test_script_B.gd")
 	var result_b_expected: String = load("res://test_mod_hook_preprocessor/test_script_B_processed.gd").source_code.trim_prefix("#")

--- a/test/test_mod_hook_preprocessor/currently_uncovered_edge_cases.gd
+++ b/test/test_mod_hook_preprocessor/currently_uncovered_edge_cases.gd
@@ -1,0 +1,7 @@
+extends Node
+
+# Ste — 09/01/2025 12:46
+# did ya know you can escape indentation O_O
+\
+ 	func what_the_hell() -> void:
+	pass

--- a/test/test_mod_hook_preprocessor/test_scene_A.tscn
+++ b/test/test_mod_hook_preprocessor/test_scene_A.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://ccew16mwmtfq7"]
+
+[ext_resource type="Script" path="res://test_mod_hook_preprocessor/test_script_A.gd" id="1_txq7h"]
+
+[node name="TestSceneA" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_txq7h")

--- a/test/test_mod_hook_preprocessor/test_script_A.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A.gd
@@ -1,0 +1,57 @@
+class_name ModHookPreprocessorTestScriptA
+extends Node
+
+
+@export var some_export_var_with_type: float = 1.11
+@export_dir var some_export_var_no_type
+
+var some_var_no_type = "text"
+var some_var_with_type: int = -1
+var some_var_with_inline_set :
+	set(new_value):
+		some_var_with_inline_set = new_value
+var some_var_with_inline_get :
+	get():
+		return some_var_with_inline_get
+var some_var_with_inline_get_set :
+	set(new_value):
+		some_var_with_inline_get_set = new_value
+	get():
+		return some_var_with_inline_get_set
+var some_var_with_set := _set_some_var_with_set
+var some_var_with_get := _get_some_var_with_get
+
+@onready var some_var_onready_no_type
+@onready var some_var_onready_with_type: String = "ready"
+
+
+func _ready() -> void:
+	some_var_no_type = "update"
+	await get_tree().create_timer(0.1).timeout
+	some_var_with_inline_set = "time has passed"
+
+
+func _process(delta: float) -> void:
+	pass
+
+
+func that_is_super() -> void:
+	pass
+
+
+func give_default() -> String:
+	return "AAAAAAHHHHHH"
+
+
+func did_you_know_you_can_realy_write_your_function___like_this(param_1: String \
+,param_2 = give_default()                 ) ->   \
+			void:
+	pass
+
+
+func _set_some_var_with_set(new_value):
+	some_var_with_set = new_value
+
+
+func _get_some_var_with_get():
+	return some_var_with_get

--- a/test/test_mod_hook_preprocessor/test_script_A.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A.gd
@@ -55,3 +55,7 @@ func _set_some_var_with_set(new_value):
 
 func _get_some_var_with_get():
 	return some_var_with_get
+
+
+func im_not_in_the_child_class() -> void:
+	pass

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -76,7 +76,8 @@ func give_default() -> String:
 	return _ModLoaderHooks.call_hooks(vanilla_2078459544_give_default, [], 3905258887)
 
 
-func did_you_know_you_can_realy_write_your_function___like_this(param_1: String, param_2=give_default()):
+func did_you_know_you_can_realy_write_your_function___like_this(param_1: String\
+, param_2=give_default()):
 	_ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
 
 

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -1,0 +1,89 @@
+#class_name ModHookPreprocessorTestScriptA
+extends Node
+
+
+@export var some_export_var_with_type: float = 1.11
+@export_dir var some_export_var_no_type
+
+var some_var_no_type = "text"
+var some_var_with_type: int = -1
+var some_var_with_inline_set :
+	set(new_value):
+		some_var_with_inline_set = new_value
+var some_var_with_inline_get :
+	get():
+		return some_var_with_inline_get
+var some_var_with_inline_get_set :
+	set(new_value):
+		some_var_with_inline_get_set = new_value
+	get():
+		return some_var_with_inline_get_set
+var some_var_with_set := _set_some_var_with_set
+var some_var_with_get := _get_some_var_with_get
+
+@onready var some_var_onready_no_type
+@onready var some_var_onready_with_type: String = "ready"
+
+
+func vanilla_2078459544__ready() -> void:
+	some_var_no_type = "update"
+	await get_tree().create_timer(0.1).timeout
+	some_var_with_inline_set = "time has passed"
+
+
+func vanilla_2078459544__process(delta: float) -> void:
+	pass
+
+
+func vanilla_2078459544_that_is_super() -> void:
+	pass
+
+
+func vanilla_2078459544_give_default() -> String:
+	return "AAAAAAHHHHHH"
+
+
+func vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this(param_1: String \
+,param_2 = give_default()                 ) ->   \
+			void:
+	pass
+
+
+func vanilla_2078459544__set_some_var_with_set(new_value):
+	some_var_with_set = new_value
+
+
+func vanilla_2078459544__get_some_var_with_get():
+	return some_var_with_get
+
+
+# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
+
+
+func _ready():
+	_ModLoaderHooks.call_hooks(vanilla_2078459544__ready, [], 2195022348)
+
+
+func _process(delta: float):
+	_ModLoaderHooks.call_hooks(vanilla_2078459544__process, [delta], 319893654)
+
+
+func that_is_super():
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_that_is_super, [], 3896778322)
+
+
+func give_default() -> String:
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544_give_default, [], 3905258887)
+
+
+func did_you_know_you_can_realy_write_your_function___like_this(param_1: String\
+, param_2=give_default()):
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
+
+
+func _set_some_var_with_set(new_value):
+	_ModLoaderHooks.call_hooks(vanilla_2078459544__set_some_var_with_set, [new_value], 1894552580)
+
+
+func _get_some_var_with_get():
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544__get_some_var_with_get, [], 2756748012)

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -61,7 +61,7 @@ func vanilla_2078459544__get_some_var_with_get():
 
 
 func _ready():
-	_ModLoaderHooks.call_hooks(vanilla_2078459544__ready, [], 2195022348)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078459544__ready, [], 2195022348)
 
 
 func _process(delta: float):

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -76,8 +76,7 @@ func give_default() -> String:
 	return _ModLoaderHooks.call_hooks(vanilla_2078459544_give_default, [], 3905258887)
 
 
-func did_you_know_you_can_realy_write_your_function___like_this(param_1: String\
-, param_2=give_default()):
+func did_you_know_you_can_realy_write_your_function___like_this(param_1: String, param_2=give_default()):
 	_ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
 
 

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -57,6 +57,10 @@ func vanilla_2078459544__get_some_var_with_get():
 	return some_var_with_get
 
 
+func vanilla_2078459544_im_not_in_the_child_class() -> void:
+	pass
+
+
 # ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
 
 
@@ -87,3 +91,7 @@ func _set_some_var_with_set(new_value):
 
 func _get_some_var_with_get():
 	return _ModLoaderHooks.call_hooks(vanilla_2078459544__get_some_var_with_get, [], 2756748012)
+
+
+func im_not_in_the_child_class():
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_im_not_in_the_child_class, [], 3426759564)

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -65,15 +65,15 @@ func vanilla_2078459544_im_not_in_the_child_class() -> void:
 
 
 func _ready():
-	return await _ModLoaderHooks.call_hooks_async(vanilla_2078459544__ready, [], 2195022348)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078459544__ready, [], 2195022348)
 
 
 func _process(delta: float):
-	return _ModLoaderHooks.call_hooks(vanilla_2078459544__process, [delta], 319893654)
+	_ModLoaderHooks.call_hooks(vanilla_2078459544__process, [delta], 319893654)
 
 
 func that_is_super():
-	return _ModLoaderHooks.call_hooks(vanilla_2078459544_that_is_super, [], 3896778322)
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_that_is_super, [], 3896778322)
 
 
 func give_default() -> String:
@@ -82,7 +82,7 @@ func give_default() -> String:
 
 func did_you_know_you_can_realy_write_your_function___like_this(param_1: String\
 , param_2=give_default()):
-	return _ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
 
 
 func _set_some_var_with_set(new_value):
@@ -94,4 +94,4 @@ func _get_some_var_with_get():
 
 
 func im_not_in_the_child_class():
-	return _ModLoaderHooks.call_hooks(vanilla_2078459544_im_not_in_the_child_class, [], 3426759564)
+	_ModLoaderHooks.call_hooks(vanilla_2078459544_im_not_in_the_child_class, [], 3426759564)

--- a/test/test_mod_hook_preprocessor/test_script_A_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_A_processed.gd
@@ -65,15 +65,15 @@ func vanilla_2078459544_im_not_in_the_child_class() -> void:
 
 
 func _ready():
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078459544__ready, [], 2195022348)
+	return await _ModLoaderHooks.call_hooks_async(vanilla_2078459544__ready, [], 2195022348)
 
 
 func _process(delta: float):
-	_ModLoaderHooks.call_hooks(vanilla_2078459544__process, [delta], 319893654)
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544__process, [delta], 319893654)
 
 
 func that_is_super():
-	_ModLoaderHooks.call_hooks(vanilla_2078459544_that_is_super, [], 3896778322)
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544_that_is_super, [], 3896778322)
 
 
 func give_default() -> String:
@@ -82,11 +82,11 @@ func give_default() -> String:
 
 func did_you_know_you_can_realy_write_your_function___like_this(param_1: String\
 , param_2=give_default()):
-	_ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544_did_you_know_you_can_realy_write_your_function___like_this, [param_1, param_2], 833669474)
 
 
 func _set_some_var_with_set(new_value):
-	_ModLoaderHooks.call_hooks(vanilla_2078459544__set_some_var_with_set, [new_value], 1894552580)
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544__set_some_var_with_set, [new_value], 1894552580)
 
 
 func _get_some_var_with_get():
@@ -94,4 +94,4 @@ func _get_some_var_with_get():
 
 
 func im_not_in_the_child_class():
-	_ModLoaderHooks.call_hooks(vanilla_2078459544_im_not_in_the_child_class, [], 3426759564)
+	return _ModLoaderHooks.call_hooks(vanilla_2078459544_im_not_in_the_child_class, [], 3426759564)

--- a/test/test_mod_hook_preprocessor/test_script_B.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B.gd
@@ -8,3 +8,7 @@ func _ready() -> void:
 
 func that_is_super() -> void:
 	super()
+
+
+func im_not_in_the_parent_class() -> void:
+	pass

--- a/test/test_mod_hook_preprocessor/test_script_B.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B.gd
@@ -1,0 +1,10 @@
+class_name ModHookPreprocessorTestScriptB
+extends ModHookPreprocessorTestScriptA
+
+
+func _ready() -> void:
+	super._ready() # I'm super ready here
+
+
+func that_is_super() -> void:
+	super()

--- a/test/test_mod_hook_preprocessor/test_script_B_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B_processed.gd
@@ -10,6 +10,10 @@ func vanilla_2078495481_that_is_super() -> void:
 	super.that_is_super()
 
 
+func vanilla_2078495481_im_not_in_the_parent_class() -> void:
+	pass
+
+
 # ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
 
 
@@ -19,3 +23,7 @@ func _ready():
 
 func that_is_super():
 	_ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)
+
+
+func im_not_in_the_parent_class():
+	_ModLoaderHooks.call_hooks(vanilla_2078495481_im_not_in_the_parent_class, [], 986863251)

--- a/test/test_mod_hook_preprocessor/test_script_B_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B_processed.gd
@@ -1,0 +1,21 @@
+#class_name ModHookPreprocessorTestScriptB
+extends ModHookPreprocessorTestScriptA
+
+
+func vanilla_2078495481__ready() -> void:
+	super._ready() # I'm super ready here
+
+
+func vanilla_2078495481_that_is_super() -> void:
+	super.that_is_super()
+
+
+# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
+
+
+func _ready():
+	_ModLoaderHooks.call_hooks(vanilla_2078495481__ready, [], 2262823725)
+
+
+func that_is_super():
+	_ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)

--- a/test/test_mod_hook_preprocessor/test_script_B_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B_processed.gd
@@ -18,12 +18,12 @@ func vanilla_2078495481_im_not_in_the_parent_class() -> void:
 
 
 func _ready():
-	_ModLoaderHooks.call_hooks(vanilla_2078495481__ready, [], 2262823725)
+	return _ModLoaderHooks.call_hooks(vanilla_2078495481__ready, [], 2262823725)
 
 
 func that_is_super():
-	_ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)
+	return _ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)
 
 
 func im_not_in_the_parent_class():
-	_ModLoaderHooks.call_hooks(vanilla_2078495481_im_not_in_the_parent_class, [], 986863251)
+	return _ModLoaderHooks.call_hooks(vanilla_2078495481_im_not_in_the_parent_class, [], 986863251)

--- a/test/test_mod_hook_preprocessor/test_script_B_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_B_processed.gd
@@ -18,12 +18,12 @@ func vanilla_2078495481_im_not_in_the_parent_class() -> void:
 
 
 func _ready():
-	return _ModLoaderHooks.call_hooks(vanilla_2078495481__ready, [], 2262823725)
+	_ModLoaderHooks.call_hooks(vanilla_2078495481__ready, [], 2262823725)
 
 
 func that_is_super():
-	return _ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)
+	_ModLoaderHooks.call_hooks(vanilla_2078495481_that_is_super, [], 2065563731)
 
 
 func im_not_in_the_parent_class():
-	return _ModLoaderHooks.call_hooks(vanilla_2078495481_im_not_in_the_parent_class, [], 986863251)
+	_ModLoaderHooks.call_hooks(vanilla_2078495481_im_not_in_the_parent_class, [], 986863251)

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -66,11 +66,14 @@ func sup_func_two(): pass
 func sup_func():
 	pass
 
-#func other_test_func():
+
+#func other_test_func(some_param: Cool):
 	#pass # test if comments match
+
 
 func other_test_func():
 	pass
+
 
 static func static_super():
 	pass

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -80,7 +80,17 @@ func this_is_so_cursed
 ():
 	pass
 
+
 func this_too\
+():
+	pass
+
+
+func please_stop\
+# wow
+# wow
+# wow
+# wow
 ():
 	pass
 
@@ -156,4 +166,4 @@ func absolutely_not_a_coroutine2(args := []):
 	# hello""", get_something()) # don't await
 
 func definitely_a_coroutine7(args := []):
-	print("# \'ello", await get_something())
+	print("# \'hello", await get_something())

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -17,13 +17,6 @@ var _seven_teen: get = actually_get_something, set= actual_setter
 var eighteen: get = actually_get_something, \
 set= actual_setter
 
-func method(
-	one, #Some comment
-	two, 	three:  int, # More comments
-		four
-):
-	pass
-
 @export var one : Vector2 = Vector2.ZERO :
 	set(value):
 		one = value
@@ -52,16 +45,29 @@ var five:
 		pass
 		get_groups()
 
+
 func _ready() -> void:
 	pass
+
+
+func method(
+	one, #Some comment
+	two, 	three:  int, # More comments
+		four
+):
+	pass
+
 
 func super_something():
 	pass
 
+
 func super_something_else():
 	print("oy")
 
+
 func sup_func_two(): pass
+
 
 func sup_func():
 	pass
@@ -69,16 +75,14 @@ func sup_func():
 
 #func other_test_func(some_param: Cool):
 	#pass # test if comments match
-
-
 func other_test_func():
 	pass
 
 
+#func more_comment_testing(some_param: Cool) -> void:
+	#pass # test if comments match
 # 	func more_comment_testing(some_param: Cool) -> void:
 	#pass # test if comments match
-
-
 func more_comment_testing() -> void:
 	pass
 
@@ -97,14 +101,17 @@ func this_too\
 	pass
 
 
+# func please_stop()
+#func please_stop()
 func please_stop\
-# wow
-# wow (
-# wow
+#func please_stop(some_param: CoolClass)
+# func please_stop(some_param: CoolClass) wow (
+# wow ()
 #( wow
 		 \
 	 ():
 	pass
+
 
 func why_would_you(put: int, \
 	backslashes := "\\", in_here := "?!\n"
@@ -124,23 +131,30 @@ class SomeTestingSubclass:
 func param_super(one: int, two: String) -> int:
 	return one
 
+
 func other_param_super(one: int, two: String) -> int:
 	return one
+
 
 func get_something():
 	return "something"
 
+
 func set_something():
 	pass
+
 
 func actually_get_something():
 	pass
 
+
 func actual_setter(val):
 	six = val
 
+
 func set_exclude_me():
 	pass
+
 
 func get_exclude_me():
 	pass
@@ -149,33 +163,41 @@ func get_exclude_me():
 func definitely_a_coroutine(args := []):
 	await tree_entered
 
+
 func definitely_a_coroutine2(args := []):
 	var callback := func():
 		print("test")
 	return await callback.callv(args)
+
 
 func definitely_a_coroutine3(args := []):
 	var callback := func():
 		print("test")
 	return await callback.callv([self] + args)
 
+
 func definitely_a_coroutine4(args := []):
 	await get_tree().create_timer(1).timeout
+
 
 func absolutely_not_a_coroutine(args := []):
 	get_something() # await is a keyword
 	pass
 
+
 func definitely_a_coroutine5(args := []):
 	print("# hello", await get_something())
+
 
 func definitely_a_coroutine6(args := []):
 	print(""" test
 	# hello""", await get_something())
 
+
 func absolutely_not_a_coroutine2(args := []):
 	print(""" test
 	# hello""", get_something()) # don't await
+
 
 func definitely_a_coroutine7(args := []):
 	print("# \'hello", await get_something())

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -103,6 +103,8 @@ func this_too\
 
 # func please_stop()
 #func please_stop()
+#      	func please_stop()
+ 	#      	func please_stop()
 func please_stop\
 #func please_stop(some_param: CoolClass)
 # func please_stop(some_param: CoolClass) wow (

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -75,6 +75,14 @@ func other_test_func():
 	pass
 
 
+# 	func more_comment_testing(some_param: Cool) -> void:
+	#pass # test if comments match
+
+
+func more_comment_testing() -> void:
+	pass
+
+
 static func static_super():
 	pass
 

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -76,7 +76,7 @@ static func static_super():
 	pass
 
 
-func this_is_so_fucking_cursed
+func this_is_so_cursed
 ():
 	pass
 

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -91,7 +91,8 @@ func please_stop\
 # wow (
 # wow
 #( wow
-():
+		 \
+	 ():
 	pass
 
 func why_would_you(put: int, \

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -1,0 +1,159 @@
+class_name ModHookPreprocessorTestScriptC
+extends Node
+
+var six: set = actual_setter
+#var six: set = set_exclude_me
+var seven: set= actual_setter, get = actually_get_something
+var eight: get = actually_get_something, set= actual_setter
+var nine: int: set= actual_setter, get = actually_get_something
+var thirteen: int: set= actual_setter ,get = actually_get_something
+var ten: Array[String]: get = actually_get_something, set= actual_setter
+var eleven: = 4 #set= set_exclude_me, get = get_exclude_me
+var twelve: set= actual_setter#, get = get_exclude_me
+var four10: get = actually_get_something, set= actual_setter
+var _5teen: get = actually_get_something, set= actual_setter
+var _16: get = actually_get_something, set= actual_setter
+var _seven_teen: get = actually_get_something, set= actual_setter
+var eighteen: get = actually_get_something, \
+set= actual_setter
+
+func method(
+	one,
+	two, 	three:  int,
+		four
+):
+	pass
+
+@export var one : Vector2 = Vector2.ZERO :
+	set(value):
+		one = value
+		print("")
+		pass
+		get_groups()
+	get:
+		return one
+
+var two: int = 0:
+	set(v): two = v
+
+var three: int = 0:
+	get: return three + 5
+
+var four: int = 0:
+	get: return three + 6
+
+var five:
+	get:
+		set_something()
+		return five *2
+	set (value):
+		one = value
+		print("")
+		pass
+		get_groups()
+
+func _ready() -> void:
+	pass
+
+func super_something():
+	pass
+
+func super_something_else():
+	print("oy")
+
+func sup_func_two(): pass
+
+func sup_func():
+	pass
+
+#func other_test_func():
+	#pass # test if comments match
+
+func other_test_func():
+	pass
+
+static func static_super():
+	pass
+
+
+func this_is_so_fucking_cursed
+():
+	pass
+
+func this_too\
+():
+	pass
+
+func why_would_you(put: int, \
+	backslashes := "\\", in_here := "?!\n"
+	):
+	pass
+
+
+class SomeTestingSubclass:
+	# check that we are not getting inner funcs with the same name
+	func get_something():
+		return "something"
+
+	func set_something():
+		pass
+
+
+func param_super(one: int, two: String) -> int:
+	return one
+
+func other_param_super(one: int, two: String) -> int:
+	return one
+
+func get_something():
+	return "something"
+
+func set_something():
+	pass
+
+func actually_get_something():
+	pass
+
+func actual_setter(val):
+	six = val
+
+func set_exclude_me():
+	pass
+
+func get_exclude_me():
+	pass
+
+
+func definitely_a_coroutine(args := []):
+	await tree_entered
+
+func definitely_a_coroutine2(args := []):
+	var callback := func():
+		print("test")
+	return await callback.callv(args)
+
+func definitely_a_coroutine3(args := []):
+	var callback := func():
+		print("test")
+	return await callback.callv([self] + args)
+
+func definitely_a_coroutine4(args := []):
+	await get_tree().create_timer(1).timeout
+
+func absolutely_not_a_coroutine(args := []):
+	get_something() # await is a keyword
+	pass
+
+func definitely_a_coroutine5(args := []):
+	print("# hello", await get_something())
+
+func definitely_a_coroutine6(args := []):
+	print(""" test
+	# hello""", await get_something())
+
+func absolutely_not_a_coroutine2(args := []):
+	print(""" test
+	# hello""", get_something()) # don't await
+
+func definitely_a_coroutine7(args := []):
+	print("# \'ello", await get_something())

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -88,9 +88,9 @@ func this_too\
 
 func please_stop\
 # wow
+# wow (
 # wow
-# wow
-# wow
+#( wow
 ():
 	pass
 

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -18,8 +18,8 @@ var eighteen: get = actually_get_something, \
 set= actual_setter
 
 func method(
-	one,
-	two, 	three:  int,
+	one, #Some comment
+	two, 	three:  int, # More comments
 		four
 ):
 	pass

--- a/test/test_mod_hook_preprocessor/test_script_C.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C.gd
@@ -79,6 +79,28 @@ func other_test_func():
 	pass
 
 
+func hello_hello() -> void:
+	pass
+
+
+func hellohello(hello: String) -> void: # Hello? hello! hello()
+	pass
+
+
+func hello_hello_2 # Hellow
+(testing: String)\
+ -> String:
+	return ""
+
+
+func hello() -> void:
+	pass
+
+
+func hello_again() -> void:
+	pass
+
+
 #func more_comment_testing(some_param: Cool) -> void:
 	#pass # test if comments match
 # 	func more_comment_testing(some_param: Cool) -> void:

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -194,7 +194,7 @@ static func static_super():
 
 
 func this_is_so_fucking_cursed():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_fucking_cursed, [], 1910726041)
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1910726041)
 
 
 func why_would_you(put: int, backslashes: ="\\", in_here: ="?!\n"):

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -197,8 +197,7 @@ func this_is_so_fucking_cursed():
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_fucking_cursed, [], 1910726041)
 
 
-func why_would_you(put: int, \
-backslashes: ="\\", in_here: ="?!\n"):
+func why_would_you(put: int, backslashes: ="\\", in_here: ="?!\n"):
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
 
 
@@ -227,19 +226,19 @@ func get_exclude_me():
 
 
 func definitely_a_coroutine(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
 
 
 func definitely_a_coroutine2(args: =[]):
-	return _ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine2, [args], 1048737840)
+	return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine2, [args], 1048737840)
 
 
 func definitely_a_coroutine3(args: =[]):
-	return _ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine3, [args], 1048737841)
+	return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine3, [args], 1048737841)
 
 
 func definitely_a_coroutine4(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
 
 
 func absolutely_not_a_coroutine(args: =[]):
@@ -247,11 +246,11 @@ func absolutely_not_a_coroutine(args: =[]):
 
 
 func definitely_a_coroutine5(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
 
 
 func definitely_a_coroutine6(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
 
 
 func absolutely_not_a_coroutine2(args: =[]):
@@ -259,4 +258,4 @@ func absolutely_not_a_coroutine2(args: =[]):
 
 
 func definitely_a_coroutine7(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)
+	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -17,13 +17,6 @@ var _seven_teen: get = actually_get_something, set= actual_setter
 var eighteen: get = actually_get_something, \
 set= actual_setter
 
-func vanilla_2078531418_method(
-	one, #Some comment
-	two, 	three:  int, # More comments
-		four
-):
-	pass
-
 @export var one : Vector2 = Vector2.ZERO :
 	set(value):
 		one = value
@@ -52,25 +45,47 @@ var five:
 		pass
 		get_groups()
 
+
 func vanilla_2078531418__ready() -> void:
 	pass
+
+
+func vanilla_2078531418_method(
+	one, #Some comment
+	two, 	three:  int, # More comments
+		four
+):
+	pass
+
 
 func vanilla_2078531418_super_something():
 	pass
 
+
 func vanilla_2078531418_super_something_else():
 	print("oy")
 
+
 func vanilla_2078531418_sup_func_two(): pass
+
 
 func vanilla_2078531418_sup_func():
 	pass
 
-#func other_test_func():
-	#pass # test if comments match
 
+#func other_test_func(some_param: Cool):
+	#pass # test if comments match
 func vanilla_2078531418_other_test_func():
 	pass
+
+
+#func more_comment_testing(some_param: Cool) -> void:
+	#pass # test if comments match
+# 	func more_comment_testing(some_param: Cool) -> void:
+	#pass # test if comments match
+func vanilla_2078531418_more_comment_testing() -> void:
+	pass
+
 
 static func vanilla_2078531418_static_super():
 	pass
@@ -84,8 +99,11 @@ func vanilla_2078531418_this_too():
 	pass
 
 
+# func please_stop()
+#func please_stop()
 func vanilla_2078531418_please_stop():
 	pass
+
 
 func vanilla_2078531418_why_would_you(put: int, \
 	backslashes := "\\", in_here := "?!\n"
@@ -105,23 +123,30 @@ class SomeTestingSubclass:
 func vanilla_2078531418_param_super(one: int, two: String) -> int:
 	return one
 
+
 func vanilla_2078531418_other_param_super(one: int, two: String) -> int:
 	return one
+
 
 func vanilla_2078531418_get_something():
 	return "something"
 
+
 func vanilla_2078531418_set_something():
 	pass
+
 
 func actually_get_something():
 	pass
 
+
 func actual_setter(val):
 	six = val
 
+
 func vanilla_2078531418_set_exclude_me():
 	pass
+
 
 func vanilla_2078531418_get_exclude_me():
 	pass
@@ -130,33 +155,41 @@ func vanilla_2078531418_get_exclude_me():
 func vanilla_2078531418_definitely_a_coroutine(args := []):
 	await tree_entered
 
+
 func vanilla_2078531418_definitely_a_coroutine2(args := []):
 	var callback := func():
 		print("test")
 	return await callback.callv(args)
+
 
 func vanilla_2078531418_definitely_a_coroutine3(args := []):
 	var callback := func():
 		print("test")
 	return await callback.callv([self] + args)
 
+
 func vanilla_2078531418_definitely_a_coroutine4(args := []):
 	await get_tree().create_timer(1).timeout
+
 
 func vanilla_2078531418_absolutely_not_a_coroutine(args := []):
 	get_something() # await is a keyword
 	pass
 
+
 func vanilla_2078531418_definitely_a_coroutine5(args := []):
 	print("# hello", await get_something())
+
 
 func vanilla_2078531418_definitely_a_coroutine6(args := []):
 	print(""" test
 	# hello""", await get_something())
 
+
 func vanilla_2078531418_absolutely_not_a_coroutine2(args := []):
 	print(""" test
 	# hello""", get_something()) # don't await
+
 
 func vanilla_2078531418_definitely_a_coroutine7(args := []):
 	print("# \'hello", await get_something())
@@ -165,112 +198,200 @@ func vanilla_2078531418_definitely_a_coroutine7(args := []):
 # ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
 
 
+func _ready():
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418__ready, [], 2330625102)
+	else:
+		vanilla_2078531418__ready()
+
+
 func method(one, #Somecomment
 two, three: int, #Morecomments
 four):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
-
-
-func _ready():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418__ready, [], 2330625102)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
+	else:
+		vanilla_2078531418_method(one, two, three, four)
 
 
 func super_something():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something, [], 561212438)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something, [], 561212438)
+	else:
+		vanilla_2078531418_super_something()
 
 
 func super_something_else():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something_else, [], 683196062)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something_else, [], 683196062)
+	else:
+		vanilla_2078531418_super_something_else()
 
 
 func sup_func_two():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func_two, [], 1626900374)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func_two, [], 1626900374)
+	else:
+		vanilla_2078531418_sup_func_two()
 
 
 func sup_func():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func, [], 1698024413)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func, [], 1698024413)
+	else:
+		vanilla_2078531418_sup_func()
 
 
 func other_test_func():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
+	else:
+		vanilla_2078531418_other_test_func()
+
+
+func more_comment_testing():
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_more_comment_testing, [], 502348540)
+	else:
+		vanilla_2078531418_more_comment_testing()
 
 
 static func static_super():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
+	else:
+		vanilla_2078531418_static_super()
 
 
 func this_is_so_cursed():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1705479347)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1705479347)
+	else:
+		vanilla_2078531418_this_is_so_cursed()
 
 
 func this_too():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
+	else:
+		vanilla_2078531418_this_too()
 
 
 func please_stop():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
+	else:
+		vanilla_2078531418_please_stop()
 
 
 func why_would_you(put: int, \
 backslashes: ="\\", in_here: ="?!\n"):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
+	else:
+		vanilla_2078531418_why_would_you(put, backslashes, in_here)
 
 
 func param_super(one: int, two: String) -> int:
-	return _ModLoaderHooks.call_hooks(vanilla_2078531418_param_super, [one, two], 2371788505)
+	if ModLoaderStore.any_mod_hooked:
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_param_super, [one, two], 2371788505)
+	else:
+		return vanilla_2078531418_param_super(one, two)
 
 
 func other_param_super(one: int, two: String) -> int:
-	return _ModLoaderHooks.call_hooks(vanilla_2078531418_other_param_super, [one, two], 2009491482)
+	if ModLoaderStore.any_mod_hooked:
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_other_param_super, [one, two], 2009491482)
+	else:
+		return vanilla_2078531418_other_param_super(one, two)
 
 
 func get_something():
-	return _ModLoaderHooks.call_hooks(vanilla_2078531418_get_something, [], 3887992391)
+	if ModLoaderStore.any_mod_hooked:
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_get_something, [], 3887992391)
+	else:
+		return vanilla_2078531418_get_something()
 
 
 func set_something():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_set_something, [], 2687664211)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_set_something, [], 2687664211)
+	else:
+		vanilla_2078531418_set_something()
 
 
 func set_exclude_me():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_set_exclude_me, [], 1755202272)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_set_exclude_me, [], 1755202272)
+	else:
+		vanilla_2078531418_set_exclude_me()
 
 
 func get_exclude_me():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_get_exclude_me, [], 2711326548)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_get_exclude_me, [], 2711326548)
+	else:
+		vanilla_2078531418_get_exclude_me()
 
 
 func definitely_a_coroutine(args: =[]):
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
+	if ModLoaderStore.any_mod_hooked:
+		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
+	else:
+		await vanilla_2078531418_definitely_a_coroutine(args)
 
 
 func definitely_a_coroutine2(args: =[]):
-	return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine2, [args], 1048737840)
+	if ModLoaderStore.any_mod_hooked:
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine2, [args], 1048737840)
+	else:
+		return await vanilla_2078531418_definitely_a_coroutine2(args)
 
 
 func definitely_a_coroutine3(args: =[]):
-	return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine3, [args], 1048737841)
+	if ModLoaderStore.any_mod_hooked:
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine3, [args], 1048737841)
+	else:
+		return await vanilla_2078531418_definitely_a_coroutine3(args)
 
 
 func definitely_a_coroutine4(args: =[]):
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
+	if ModLoaderStore.any_mod_hooked:
+		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
+	else:
+		await vanilla_2078531418_definitely_a_coroutine4(args)
 
 
 func absolutely_not_a_coroutine(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine, [args], 2502244037)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine, [args], 2502244037)
+	else:
+		vanilla_2078531418_absolutely_not_a_coroutine(args)
 
 
 func definitely_a_coroutine5(args: =[]):
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
+	if ModLoaderStore.any_mod_hooked:
+		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
+	else:
+		await vanilla_2078531418_definitely_a_coroutine5(args)
 
 
 func definitely_a_coroutine6(args: =[]):
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
+	if ModLoaderStore.any_mod_hooked:
+		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
+	else:
+		await vanilla_2078531418_definitely_a_coroutine6(args)
 
 
 func absolutely_not_a_coroutine2(args: =[]):
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine2, [args], 969674647)
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine2, [args], 969674647)
+	else:
+		vanilla_2078531418_absolutely_not_a_coroutine2(args)
 
 
 func definitely_a_coroutine7(args: =[]):
-	await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)
+	if ModLoaderStore.any_mod_hooked:
+		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)
+	else:
+		await vanilla_2078531418_definitely_a_coroutine7(args)

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -1,0 +1,262 @@
+#class_name ModHookPreprocessorTestScriptC
+extends Node
+
+var six: set = actual_setter
+#var six: set = set_exclude_me
+var seven: set= actual_setter, get = actually_get_something
+var eight: get = actually_get_something, set= actual_setter
+var nine: int: set= actual_setter, get = actually_get_something
+var thirteen: int: set= actual_setter ,get = actually_get_something
+var ten: Array[String]: get = actually_get_something, set= actual_setter
+var eleven: = 4 #set= set_exclude_me, get = get_exclude_me
+var twelve: set= actual_setter#, get = get_exclude_me
+var four10: get = actually_get_something, set= actual_setter
+var _5teen: get = actually_get_something, set= actual_setter
+var _16: get = actually_get_something, set= actual_setter
+var _seven_teen: get = actually_get_something, set= actual_setter
+var eighteen: get = actually_get_something, \
+set= actual_setter
+
+func vanilla_2078531418_method(
+	one,
+	two, 	three:  int,
+		four
+):
+	pass
+
+@export var one : Vector2 = Vector2.ZERO :
+	set(value):
+		one = value
+		print("")
+		pass
+		get_groups()
+	get:
+		return one
+
+var two: int = 0:
+	set(v): two = v
+
+var three: int = 0:
+	get: return three + 5
+
+var four: int = 0:
+	get: return three + 6
+
+var five:
+	get:
+		set_something()
+		return five *2
+	set (value):
+		one = value
+		print("")
+		pass
+		get_groups()
+
+func vanilla_2078531418__ready() -> void:
+	pass
+
+func vanilla_2078531418_super_something():
+	pass
+
+func vanilla_2078531418_super_something_else():
+	print("oy")
+
+func vanilla_2078531418_sup_func_two(): pass
+
+func vanilla_2078531418_sup_func():
+	pass
+
+#func other_test_func():
+	#pass # test if comments match
+
+func vanilla_2078531418_other_test_func():
+	pass
+
+static func vanilla_2078531418_static_super():
+	pass
+
+
+func vanilla_2078531418_this_is_so_fucking_cursed():
+	pass
+
+func this_too\
+():
+	pass
+
+func vanilla_2078531418_why_would_you(put: int, \
+	backslashes := "\\", in_here := "?!\n"
+	):
+	pass
+
+
+class SomeTestingSubclass:
+	# check that we are not getting inner funcs with the same name
+	func get_something():
+		return "something"
+
+	func set_something():
+		pass
+
+
+func vanilla_2078531418_param_super(one: int, two: String) -> int:
+	return one
+
+func vanilla_2078531418_other_param_super(one: int, two: String) -> int:
+	return one
+
+func vanilla_2078531418_get_something():
+	return "something"
+
+func vanilla_2078531418_set_something():
+	pass
+
+func actually_get_something():
+	pass
+
+func actual_setter(val):
+	six = val
+
+func vanilla_2078531418_set_exclude_me():
+	pass
+
+func vanilla_2078531418_get_exclude_me():
+	pass
+
+
+func vanilla_2078531418_definitely_a_coroutine(args := []):
+	await tree_entered
+
+func vanilla_2078531418_definitely_a_coroutine2(args := []):
+	var callback := func():
+		print("test")
+	return await callback.callv(args)
+
+func vanilla_2078531418_definitely_a_coroutine3(args := []):
+	var callback := func():
+		print("test")
+	return await callback.callv([self] + args)
+
+func vanilla_2078531418_definitely_a_coroutine4(args := []):
+	await get_tree().create_timer(1).timeout
+
+func vanilla_2078531418_absolutely_not_a_coroutine(args := []):
+	get_something() # await is a keyword
+	pass
+
+func vanilla_2078531418_definitely_a_coroutine5(args := []):
+	print("# hello", await get_something())
+
+func vanilla_2078531418_definitely_a_coroutine6(args := []):
+	print(""" test
+	# hello""", await get_something())
+
+func vanilla_2078531418_absolutely_not_a_coroutine2(args := []):
+	print(""" test
+	# hello""", get_something()) # don't await
+
+func vanilla_2078531418_definitely_a_coroutine7(args := []):
+	print("# \'ello", await get_something())
+
+
+# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
+
+
+func method(one, two, three: int, four):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
+
+
+func _ready():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418__ready, [], 2330625102)
+
+
+func super_something():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something, [], 561212438)
+
+
+func super_something_else():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something_else, [], 683196062)
+
+
+func sup_func_two():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func_two, [], 1626900374)
+
+
+func sup_func():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func, [], 1698024413)
+
+
+func other_test_func():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
+
+
+static func static_super():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
+
+
+func this_is_so_fucking_cursed():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_fucking_cursed, [], 1910726041)
+
+
+func why_would_you(put: int, \
+backslashes: ="\\", in_here: ="?!\n"):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
+
+
+func param_super(one: int, two: String) -> int:
+	return _ModLoaderHooks.call_hooks(vanilla_2078531418_param_super, [one, two], 2371788505)
+
+
+func other_param_super(one: int, two: String) -> int:
+	return _ModLoaderHooks.call_hooks(vanilla_2078531418_other_param_super, [one, two], 2009491482)
+
+
+func get_something():
+	return _ModLoaderHooks.call_hooks(vanilla_2078531418_get_something, [], 3887992391)
+
+
+func set_something():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_set_something, [], 2687664211)
+
+
+func set_exclude_me():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_set_exclude_me, [], 1755202272)
+
+
+func get_exclude_me():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_get_exclude_me, [], 2711326548)
+
+
+func definitely_a_coroutine(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
+
+
+func definitely_a_coroutine2(args: =[]):
+	return _ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine2, [args], 1048737840)
+
+
+func definitely_a_coroutine3(args: =[]):
+	return _ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine3, [args], 1048737841)
+
+
+func definitely_a_coroutine4(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
+
+
+func absolutely_not_a_coroutine(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine, [args], 2502244037)
+
+
+func definitely_a_coroutine5(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
+
+
+func definitely_a_coroutine6(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
+
+
+func absolutely_not_a_coroutine2(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine2, [args], 969674647)
+
+
+func definitely_a_coroutine7(args: =[]):
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -79,6 +79,27 @@ func vanilla_2078531418_other_test_func():
 	pass
 
 
+func vanilla_2078531418_hello_hello() -> void:
+	pass
+
+
+func vanilla_2078531418_hellohello(hello: String) -> void: # Hello? hello! hello()
+	pass
+
+
+func vanilla_2078531418_hello_hello_2(testing: String)\
+ -> String:
+	return ""
+
+
+func vanilla_2078531418_hello() -> void:
+	pass
+
+
+func vanilla_2078531418_hello_again() -> void:
+	pass
+
+
 #func more_comment_testing(some_param: Cool) -> void:
 	#pass # test if comments match
 # 	func more_comment_testing(some_param: Cool) -> void:
@@ -249,6 +270,41 @@ func other_test_func():
 		_ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
 	else:
 		vanilla_2078531418_other_test_func()
+
+
+func hello_hello():
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_hello_hello, [], 2008108737)
+	else:
+		vanilla_2078531418_hello_hello()
+
+
+func hellohello(hello: String):
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_hellohello, [hello], 1633231170)
+	else:
+		vanilla_2078531418_hellohello(hello)
+
+
+func hello_hello_2(testing: String) -> String:
+	if ModLoaderStore.any_mod_hooked:
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_hello_hello_2, [testing], 692064114)
+	else:
+		return vanilla_2078531418_hello_hello_2(testing)
+
+
+func hello():
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_hello, [], 1772795918)
+	else:
+		vanilla_2078531418_hello()
+
+
+func hello_again():
+	if ModLoaderStore.any_mod_hooked:
+		_ModLoaderHooks.call_hooks(vanilla_2078531418_hello_again, [], 1999867085)
+	else:
+		vanilla_2078531418_hello_again()
 
 
 func more_comment_testing():

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -79,7 +79,12 @@ static func vanilla_2078531418_static_super():
 func vanilla_2078531418_this_is_so_cursed():
 	pass
 
+
 func vanilla_2078531418_this_too():
+	pass
+
+
+func vanilla_2078531418_please_stop():
 	pass
 
 func vanilla_2078531418_why_would_you(put: int, \
@@ -154,7 +159,7 @@ func vanilla_2078531418_absolutely_not_a_coroutine2(args := []):
 	# hello""", get_something()) # don't await
 
 func vanilla_2078531418_definitely_a_coroutine7(args := []):
-	print("# \'ello", await get_something())
+	print("# \'hello", await get_something())
 
 
 # ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
@@ -198,6 +203,10 @@ func this_is_so_cursed():
 
 func this_too():
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
+
+
+func please_stop():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
 
 
 func why_would_you(put: int, backslashes: ="\\", in_here: ="?!\n"):

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -76,7 +76,7 @@ static func vanilla_2078531418_static_super():
 	pass
 
 
-func vanilla_2078531418_this_is_so_fucking_cursed():
+func vanilla_2078531418_this_is_so_cursed():
 	pass
 
 func this_too\

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -79,8 +79,7 @@ static func vanilla_2078531418_static_super():
 func vanilla_2078531418_this_is_so_cursed():
 	pass
 
-func this_too\
-():
+func vanilla_2078531418_this_too():
 	pass
 
 func vanilla_2078531418_why_would_you(put: int, \
@@ -193,8 +192,12 @@ static func static_super():
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
 
 
-func this_is_so_fucking_cursed():
-	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1910726041)
+func this_is_so_cursed():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1705479347)
+
+
+func this_too():
+	_ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
 
 
 func why_would_you(put: int, backslashes: ="\\", in_here: ="?!\n"):

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -101,6 +101,8 @@ func vanilla_2078531418_this_too():
 
 # func please_stop()
 #func please_stop()
+#      	func please_stop()
+ 	#      	func please_stop()
 func vanilla_2078531418_please_stop():
 	pass
 

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -18,8 +18,8 @@ var eighteen: get = actually_get_something, \
 set= actual_setter
 
 func vanilla_2078531418_method(
-	one,
-	two, 	three:  int,
+	one, #Some comment
+	two, 	three:  int, # More comments
 		four
 ):
 	pass
@@ -165,7 +165,9 @@ func vanilla_2078531418_definitely_a_coroutine7(args := []):
 # ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader.
 
 
-func method(one, two, three: int, four):
+func method(one, #Somecomment
+two, three: int, #Morecomments
+four):
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
 
 
@@ -209,7 +211,8 @@ func please_stop():
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
 
 
-func why_would_you(put: int, backslashes: ="\\", in_here: ="?!\n"):
+func why_would_you(put: int, \
+backslashes: ="\\", in_here: ="?!\n"):
 	_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
 
 

--- a/test/test_mod_hook_preprocessor/test_script_C_processed.gd
+++ b/test/test_mod_hook_preprocessor/test_script_C_processed.gd
@@ -232,44 +232,44 @@ func method(one, #Somecomment
 two, three: int, #Morecomments
 four):
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
 	else:
-		vanilla_2078531418_method(one, two, three, four)
+		return vanilla_2078531418_method(one, two, three, four)
 
 
 func super_something():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something, [], 561212438)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_super_something, [], 561212438)
 	else:
-		vanilla_2078531418_super_something()
+		return vanilla_2078531418_super_something()
 
 
 func super_something_else():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_super_something_else, [], 683196062)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_super_something_else, [], 683196062)
 	else:
-		vanilla_2078531418_super_something_else()
+		return vanilla_2078531418_super_something_else()
 
 
 func sup_func_two():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func_two, [], 1626900374)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func_two, [], 1626900374)
 	else:
-		vanilla_2078531418_sup_func_two()
+		return vanilla_2078531418_sup_func_two()
 
 
 func sup_func():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func, [], 1698024413)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_sup_func, [], 1698024413)
 	else:
-		vanilla_2078531418_sup_func()
+		return vanilla_2078531418_sup_func()
 
 
 func other_test_func():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_other_test_func, [], 124073286)
 	else:
-		vanilla_2078531418_other_test_func()
+		return vanilla_2078531418_other_test_func()
 
 
 func hello_hello():
@@ -316,38 +316,38 @@ func more_comment_testing():
 
 static func static_super():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_static_super, [], 1720709936)
 	else:
-		vanilla_2078531418_static_super()
+		return vanilla_2078531418_static_super()
 
 
 func this_is_so_cursed():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1705479347)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_this_is_so_cursed, [], 1705479347)
 	else:
-		vanilla_2078531418_this_is_so_cursed()
+		return vanilla_2078531418_this_is_so_cursed()
 
 
 func this_too():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_this_too, [], 1507098083)
 	else:
-		vanilla_2078531418_this_too()
+		return vanilla_2078531418_this_too()
 
 
 func please_stop():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_please_stop, [], 2851245561)
 	else:
-		vanilla_2078531418_please_stop()
+		return vanilla_2078531418_please_stop()
 
 
 func why_would_you(put: int, \
 backslashes: ="\\", in_here: ="?!\n"):
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_why_would_you, [put, backslashes, in_here], 1414126584)
 	else:
-		vanilla_2078531418_why_would_you(put, backslashes, in_here)
+		return vanilla_2078531418_why_would_you(put, backslashes, in_here)
 
 
 func param_super(one: int, two: String) -> int:
@@ -373,30 +373,30 @@ func get_something():
 
 func set_something():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_set_something, [], 2687664211)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_set_something, [], 2687664211)
 	else:
-		vanilla_2078531418_set_something()
+		return vanilla_2078531418_set_something()
 
 
 func set_exclude_me():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_set_exclude_me, [], 1755202272)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_set_exclude_me, [], 1755202272)
 	else:
-		vanilla_2078531418_set_exclude_me()
+		return vanilla_2078531418_set_exclude_me()
 
 
 func get_exclude_me():
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_get_exclude_me, [], 2711326548)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_get_exclude_me, [], 2711326548)
 	else:
-		vanilla_2078531418_get_exclude_me()
+		return vanilla_2078531418_get_exclude_me()
 
 
 func definitely_a_coroutine(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine, [args], 1072984126)
 	else:
-		await vanilla_2078531418_definitely_a_coroutine(args)
+		return await vanilla_2078531418_definitely_a_coroutine(args)
 
 
 func definitely_a_coroutine2(args: =[]):
@@ -415,41 +415,41 @@ func definitely_a_coroutine3(args: =[]):
 
 func definitely_a_coroutine4(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine4, [args], 1048737842)
 	else:
-		await vanilla_2078531418_definitely_a_coroutine4(args)
+		return await vanilla_2078531418_definitely_a_coroutine4(args)
 
 
 func absolutely_not_a_coroutine(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine, [args], 2502244037)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine, [args], 2502244037)
 	else:
-		vanilla_2078531418_absolutely_not_a_coroutine(args)
+		return vanilla_2078531418_absolutely_not_a_coroutine(args)
 
 
 func definitely_a_coroutine5(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine5, [args], 1048737843)
 	else:
-		await vanilla_2078531418_definitely_a_coroutine5(args)
+		return await vanilla_2078531418_definitely_a_coroutine5(args)
 
 
 func definitely_a_coroutine6(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine6, [args], 1048737844)
 	else:
-		await vanilla_2078531418_definitely_a_coroutine6(args)
+		return await vanilla_2078531418_definitely_a_coroutine6(args)
 
 
 func absolutely_not_a_coroutine2(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		_ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine2, [args], 969674647)
+		return _ModLoaderHooks.call_hooks(vanilla_2078531418_absolutely_not_a_coroutine2, [args], 969674647)
 	else:
-		vanilla_2078531418_absolutely_not_a_coroutine2(args)
+		return vanilla_2078531418_absolutely_not_a_coroutine2(args)
 
 
 func definitely_a_coroutine7(args: =[]):
 	if ModLoaderStore.any_mod_hooked:
-		await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)
+		return await _ModLoaderHooks.call_hooks_async(vanilla_2078531418_definitely_a_coroutine7, [args], 1048737845)
 	else:
-		await vanilla_2078531418_definitely_a_coroutine7(args)
+		return await vanilla_2078531418_definitely_a_coroutine7(args)


### PR DESCRIPTION
This adds 3 test scripts (`test_script_A / B / C.gd`) with their expected results (`test_script_A / B/ C_processed.gd`) to validate the functionality of `_ModLoaderModHookPreProcessor.process_script()`.

> [!NOTE]
>  The `class_name` in the `_processed.gd` scripts must be commented out to avoid the "hiding global class" error.
> Test run is broken until #495 is merged or `func please_stop` is removed from test script C.

## TODO

- [x] #494 

---

<details><summary>Dev Notes</summary>
<p>

- add this to the test script 
```gdscript
format_date(day: int, \
month: int, year: int, special_thing := "\n\t\"\
")
```
- I think this covers it quiet well already:
```gdscript
func why_would_you(put: int, \
	backslashes := "\\", in_here := "?!\n"
	):
	pass
```

</p>
</details> 