### PR TITLE
fix: :bug: fix `\` breaking function declaration

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -251,7 +251,8 @@ static func get_function_parameters(method_name: String, text: String, is_static
 		.replace("\n", "")\
 		.replace("\t", "")\
 		.replace(",", ", ")\
-		.replace(":", ": ")
+		.replace(":", ": ")\
+		.replace("\\", "")
 
 	return param_string
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -248,11 +248,11 @@ static func get_function_parameters(method_name: String, text: String, is_static
 	# Clean whitespace characters (spaces, newlines, tabs)
 	param_string = param_string.strip_edges()\
 		.replace(" ", "")\
+		.replace("\\\n", "")\
 		.replace("\n", "")\
 		.replace("\t", "")\
 		.replace(",", ", ")\
-		.replace(":", ": ")\
-		.replace("\\", "")
+		.replace(":", ": ")
 
 	return param_string
 


### PR DESCRIPTION
- Added replacing of `\` with `""` in `_ModLoaderModHookPreProcessor.get_function_parameters()`

closes #472