### PR TITLE
fix: 🐛 match `\` and new line

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -313,7 +313,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s\\\\?\\s*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s[\\\\s]*\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -313,7 +313,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s\\s*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s\\\\?\\s*\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -313,7 +313,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s[\\\\s]*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s[\\\\\\s]*\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 


### PR DESCRIPTION
closes #488