### PR TITLE
fix: :bug: match any character between func name and `(`

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -337,7 +337,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s[\\\\\\s]*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(.*\\n*)*?\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -337,7 +337,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(.*\\n*)*?\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(?:.*\\n*)*?\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -14,11 +14,11 @@ const HASH_COLLISION_ERROR := \
 const MOD_LOADER_HOOKS_START_STRING := \
 	"\n# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader."
 
-## \\bfunc\\s+		->	Match the word 'func' and one or more whitespace characters
-## \\b%s 				->	the function name
+## \\bfunc\\b\\s+		->	Match the word 'func' and one or more whitespace characters
+## \\b%s\\b 			->	the function name
 ## (?:.*\\n*)*?\\s*\\( 	->	Match any character between zero and unlimited times, but be lazy
-## 						and only do this until a '(' is found.
-const REGEX_MATCH_FUNC_WITH_WHITESPACE := "\\bfunc\\s+\\b%s(?:.*\\n*)*?\\s*\\("
+## 							and only do this until a '(' is found.
+const REGEX_MATCH_FUNC_WITH_WHITESPACE := "\\bfunc\\b\\s+\\b%s\\b(?:.*\\n*)*?\\s*\\("
 
 ## finds function names used as setters and getters (excluding inline definitions)
 ## group 2 and 4 contain the xetter names

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -14,6 +14,12 @@ const HASH_COLLISION_ERROR := \
 const MOD_LOADER_HOOKS_START_STRING := \
 	"\n# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader."
 
+## (?<!#)			->	Ingore matches if 'func' is preceded by a '#'
+## \bfunc\\s+		->	Match the word 'func' and one or more whitespace characters
+## %s 				->	the function name
+## (?:.*\\n*)*?\\( 	->	Match any character between zero and unlimited times, but be lazy
+## 						and only do this until a '(' is found.
+const REGEX_MATCH_FUNC_WITH_WHITESPACE := "(?<!#)\\bfunc\\s+%s(?:.*\\n*)*?\\("
 
 ## finds function names used as setters and getters (excluding inline definitions)
 ## group 2 and 4 contain the xetter names
@@ -337,7 +343,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("(?<!#)\\bfunc\\s+%s(?:.*\\n*)*?\\s*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string(REGEX_MATCH_FUNC_WITH_WHITESPACE % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -15,11 +15,11 @@ const MOD_LOADER_HOOKS_START_STRING := \
 	"\n# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader."
 
 ## (?<!#)			->	Ingore matches if 'func' is preceded by a '#'
-## \bfunc\\s+		->	Match the word 'func' and one or more whitespace characters
-## %s 				->	the function name
-## (?:.*\\n*)*?\\( 	->	Match any character between zero and unlimited times, but be lazy
+## \\bfunc\\s+		->	Match the word 'func' and one or more whitespace characters
+## \\b%s 				->	the function name
+## (?:.*\\n*)*?\\s*\\( 	->	Match any character between zero and unlimited times, but be lazy
 ## 						and only do this until a '(' is found.
-const REGEX_MATCH_FUNC_WITH_WHITESPACE := "(?<!#)\\bfunc\\s+%s(?:.*\\n*)*?\\("
+const REGEX_MATCH_FUNC_WITH_WHITESPACE := "(?<!#)\\bfunc\\s+\\b%s(?:.*\\n*)*?\\s*\\("
 
 ## finds function names used as setters and getters (excluding inline definitions)
 ## group 2 and 4 contain the xetter names

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -337,7 +337,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(?:.*\\n*)*?\\s*\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("(?<!#)\\bfunc\\s+%s(?:.*\\n*)*?\\s*\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -14,12 +14,11 @@ const HASH_COLLISION_ERROR := \
 const MOD_LOADER_HOOKS_START_STRING := \
 	"\n# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader."
 
-## (?<!#)			->	Ingore matches if 'func' is preceded by a '#'
 ## \\bfunc\\s+		->	Match the word 'func' and one or more whitespace characters
 ## \\b%s 				->	the function name
 ## (?:.*\\n*)*?\\s*\\( 	->	Match any character between zero and unlimited times, but be lazy
 ## 						and only do this until a '(' is found.
-const REGEX_MATCH_FUNC_WITH_WHITESPACE := "(?<!#)\\bfunc\\s+\\b%s(?:.*\\n*)*?\\s*\\("
+const REGEX_MATCH_FUNC_WITH_WHITESPACE := "\\bfunc\\s+\\b%s(?:.*\\n*)*?\\s*\\("
 
 ## finds function names used as setters and getters (excluding inline definitions)
 ## group 2 and 4 contain the xetter names

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -337,7 +337,7 @@ func match_method_body(method_name: String, func_body_start_index: int, text: St
 
 static func match_func_with_whitespace(method_name: String, text: String, offset := 0) -> RegExMatch:
 	# Dynamically create the new regex for that specific name
-	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(?:.*\\n*)*?\\(" % method_name)
+	var func_with_whitespace := RegEx.create_from_string("func\\s+%s(?:.*\\n*)*?\\s*\\(" % method_name)
 	return func_with_whitespace.search(text, offset)
 
 


### PR DESCRIPTION
- Changed `func\\s+%s[\\\\\\s]*\\(` to `\\bfunc\\b\\s+\\b%s\\b(?:.*\\n*)*?\\s*\\(`
   - Comments and non top level funcs are ignored with `is_top_level_func()` and not handled by this regex
- Moved the regex to the top with the other regexes
- Added a description comment 
   ```gdscript
   ## \\bfunc\\b\\s+		->	Match the word 'func' and one or more whitespace characters
   ## \\b%s\\b 			->	the function name
   ## (?:.*\\n*)*?\\s*\\( 	->	Match any character between zero and unlimited times, but be lazy
   ## 							and only do this until a '(' is found.
   ```

Tested with #476 and a smaller game via export plugin on 4.3.

closes #494 