### PR TITLE
fix: :bug: don't remove new lines in `param_string`

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -268,8 +268,6 @@ static func get_function_parameters(method_name: String, text: String, is_static
 	# Clean whitespace characters (spaces, newlines, tabs)
 	param_string = param_string.strip_edges()\
 		.replace(" ", "")\
-		.replace("\\\n", "")\
-		.replace("\n", "")\
 		.replace("\t", "")\
 		.replace(",", ", ")\
 		.replace(":", ": ")


### PR DESCRIPTION
Removing new lines in function parameters can cause unintended side effects.  
The following example demonstrates how this can break the generated code:


```gdscript
func method(
	one, #Some comment
	two, 	three:  int, # More comments
		four
):
	pass
```

Generates:

```gdscript
func method(one, #Somecommenttwo, three: int, #Morecommentsfour):
	_ModLoaderHooks.call_hooks(vanilla_2078531418_method, [one, two, three, four], 2863650651)
```



closes #496