### PR TITLE
fix: :bug: resolved parser error because of missing return value

### DIFF
--- a/addons/mod_loader/_export_plugin/export_plugin.gd
+++ b/addons/mod_loader/_export_plugin/export_plugin.gd
@@ -22,6 +22,6 @@ func _export_file(path: String, type: String, features: PackedStringArray) -> vo
 	skip()
 	add_file(
 		path,
-		hook_pre_processor.process_script_verbose(path, true).to_utf8_buffer(),
+		hook_pre_processor.process_script(path, true).to_utf8_buffer(),
 		false
 	)


### PR DESCRIPTION
Added an else statement that directly calls or returns the vanilla function if `any_mod_hooked` is `false`.

Result:
```gdscript
func _ready():
	if ModLoaderStore.any_mod_hooked:
		_ModLoaderHooks.call_hooks(vanilla_3694473935__ready, [], 1946934147)
	else:
		vanilla_3694473935__ready()


func play_global_sfx(audio: AudioStream, db: float=0.0, delay: =0.0, pitch_scale: float=randf_range(0.85, 1.2)):
	if ModLoaderStore.any_mod_hooked:
		await _ModLoaderHooks.call_hooks_async(vanilla_2851983457_play_global_sfx, [audio, db, delay, pitch_scale], 2151934167)
	else:
		await vanilla_2851983457_play_global_sfx(audio, db, delay, pitch_scale)


func check_sight(target_position: Vector3) -> bool:
	if ModLoaderStore.any_mod_hooked:
		return _ModLoaderHooks.call_hooks(vanilla_608418131_check_sight, [target_position], 1845897103)
	else:
		return vanilla_608418131_check_sight(target_position)
```

closes #487
closes #437
