### PR TITLE
Feat: Logging without store

### DIFF
--- a/addons/mod_loader/api/deprecated.gd
+++ b/addons/mod_loader/api/deprecated.gd
@@ -67,6 +67,6 @@ static func deprecated_message(msg: String, since_version: String = "") -> void:
 ## - [code]void[/code]
 static func _deprecated_log(msg: String) -> void:
 	if ModLoaderStore and ModLoaderStore.ml_options.ignore_deprecated_errors or OS.has_feature("standalone"):
-		ModLoaderLog.warning(msg, LOG_NAME)
+		ModLoaderLog.warning(msg, LOG_NAME, true)
 	else:
-		ModLoaderLog.fatal(msg, LOG_NAME)
+		ModLoaderLog.fatal(msg, LOG_NAME, true)

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -8,18 +8,19 @@ extends Object
 # Path to the latest log file.
 const MOD_LOG_PATH := "user://logs/modloader.log"
 
-const LOG_NAME := "ModLoader:Log"
+const _LOG_NAME := "ModLoader:Log"
 
+## Denotes the severity of a log entry
 enum VERBOSITY_LEVEL {
-	ERROR,
-	WARNING,
-	INFO,
-	DEBUG,
+	ERROR, 		## For errors and fatal errors
+	WARNING, 	## For warnings
+	INFO, 		## For everything informational and successes
+	DEBUG, 		## For debugging, can get quite verbose
 }
 
-# Keeps track of logged messages, to avoid flooding the log with duplicate notices
-# Can also be used by mods, eg. to create an in-game developer console that
-# shows messages
+## Keeps track of logged messages, to avoid flooding the log with duplicate notices
+## Can also be used by mods, eg. to create an in-game developer console that
+## shows messages
 static var logged_messages := {
 	"all": {},
 	"by_mod": {},
@@ -33,9 +34,12 @@ static var logged_messages := {
 	}
 }
 
+## Verbosity/Logging level.
+## Used to filter out messages below the set level
+## (if the [enum VERBOSITY_LEVEL] int of a new entry is larger than the [member verbosity] it is ignored)
 static var verbosity: VERBOSITY_LEVEL = VERBOSITY_LEVEL.DEBUG
 
-# Array of mods that should be ignored when logging messages (contains mod IDs as strings)
+## Array of mods that should be ignored when logging messages (contains mod IDs as strings)
 static var ignored_mods: Array[String] = []
 
 
@@ -68,10 +72,10 @@ class ModLoaderLogEntry:
 	## Initialize a ModLoaderLogEntry object with provided values.[br]
 	##[br]
 	## [b]Parameters:[/b][br]
-	## - [code]_mod_name[/code] ([String]): Name of the mod or ModLoader class this entry refers to.[br]
-	## - [code]_message[/code] ([String]): The message of the log entry.[br]
-	## - [code]_type[/code] ([String]): The log type, which indicates the verbosity level of this entry.[br]
-	## - [code]_time[/code] ([String]): The readable format of the time when this log entry was created.[br]
+	## [param _mod_name] ([String]): Name of the mod or ModLoader class this entry refers to.[br]
+	## [param _message] ([String]): The message of the log entry.[br]
+	## [param _type] ([String]): The log type, which indicates the verbosity level of this entry.[br]
+	## [param _time] ([String]): The readable format of the time when this log entry was created.[br]
 	##[br]
 	## [b]Returns:[/b] [code]void[/code]
 	func _init(_mod_name: String, _message: String, _type: String, _time: String) -> void:
@@ -122,9 +126,9 @@ class ModLoaderLogEntry:
 ## [i]Note: Stops the execution in editor[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as an error.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as an error.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func fatal(message: String, mod_name: String, only_once := false) -> void:
@@ -136,9 +140,9 @@ static func fatal(message: String, mod_name: String, only_once := false) -> void
 ## [i]Note: Always logged[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as an error.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as an error.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func error(message: String, mod_name: String, only_once := false) -> void:
@@ -150,9 +154,9 @@ static func error(message: String, mod_name: String, only_once := false) -> void
 ## [i]Note: Logged with verbosity level at or above warning (-v).[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as a warning.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as a warning.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func warning(message: String, mod_name: String, only_once := false) -> void:
@@ -164,9 +168,9 @@ static func warning(message: String, mod_name: String, only_once := false) -> vo
 ## [i]Note: Logged with verbosity level at or above info (-vv).[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as an information.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as an information.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func info(message: String, mod_name: String, only_once := false) -> void:
@@ -178,9 +182,9 @@ static func info(message: String, mod_name: String, only_once := false) -> void:
 ## [i]Note: Logged with verbosity level at or above info (-vv).[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as a success.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as a success.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func success(message: String, mod_name: String, only_once := false) -> void:
@@ -192,9 +196,9 @@ static func success(message: String, mod_name: String, only_once := false) -> vo
 ## [i]Note: Logged with verbosity level at or above debug (-vvv).[/i][br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as a debug.[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as a debug.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ## [br]
 ## [b]Returns:[/b] [code]void[/code]
 static func debug(message: String, mod_name: String, only_once := false) -> void:
@@ -206,10 +210,10 @@ static func debug(message: String, mod_name: String, only_once := false) -> void
 ## [i]Note: Logged with verbosity level at or above debug (-vvv).[/i] [br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]message[/code] ([String]): The message to be logged as a debug.[br]
-## - [code]json_printable[/code] (Variant): The variable to be formatted and printed using [method JSON.print].[br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
-## - [code]only_once[/code] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
+## [param message] ([String]): The message to be logged as a debug.[br]
+## [param json_printable] (Variant): The variable to be formatted and printed using [method JSON.print].[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with this log entry.[br]
+## [param only_once] ([bool]): (Optional) If true, the log entry will only be logged once, even if called multiple times. Default is false.[br]
 ##
 ## [b]Returns:[/b] [code]void[/code]
 static func debug_json_print(message: String, json_printable, mod_name: String, only_once := false) -> void:
@@ -241,7 +245,7 @@ static func get_all_as_string() -> Array:
 ## Returns an array of log entries as a resource for a specific mod_name.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries represented as resource for the specified [code]mod_name[/code].
@@ -252,7 +256,7 @@ static func get_by_mod_as_resource(mod_name: String) -> Array:
 ## Returns an array of log entries as a string for a specific mod_name.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries represented as strings for the specified [code]mod_name[/code].
@@ -264,7 +268,7 @@ static func get_by_mod_as_string(mod_name: String) -> Array:
 ## Returns an array of log entries as a resource for a specific type.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]type[/code] ([String]): The log type associated with the log entries.[br]
+## [param type] ([String]): The log type associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries represented as resource for the specified [code]type[/code].
@@ -275,7 +279,7 @@ static func get_by_type_as_resource(type: String) -> Array:
 ## Returns an array of log entries as a string for a specific type.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]type[/code] ([String]): The log type associated with the log entries.[br]
+## [param type] ([String]): The log type associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries represented as strings for the specified [code]type[/code].
@@ -305,7 +309,7 @@ static func get_all() -> Array:
 ## Returns an array of log entries for a specific mod_name.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]mod_name[/code] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
+## [param mod_name] ([String]): The name of the mod or ModLoader class associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries for the specified [code]mod_name[/code].
@@ -313,7 +317,7 @@ static func get_by_mod(mod_name: String) -> Array:
 	var log_entries := []
 
 	if not logged_messages.by_mod.has(mod_name):
-		error("\"%s\" not found in logged messages." % mod_name, LOG_NAME)
+		error("\"%s\" not found in logged messages." % mod_name, _LOG_NAME)
 		return []
 
 	for entry_key in logged_messages.by_mod[mod_name].keys():
@@ -326,7 +330,7 @@ static func get_by_mod(mod_name: String) -> Array:
 ## Returns an array of log entries for a specific type.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]type[/code] ([String]): The log type associated with the log entries.[br]
+## [param type] ([String]): The log type associated with the log entries.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries for the specified [code]type[/code].
@@ -343,7 +347,7 @@ static func get_by_type(type: String) -> Array:
 ## Returns an array of log entries represented as strings.[br]
 ## [br]
 ## [b]Parameters:[/b][br]
-## - [code]log_entries[/code] ([Array]): An array of ModLoaderLogEntry Objects.[br]
+## [param log_entries] ([Array]): An array of ModLoaderLogEntry Objects.[br]
 ## [br]
 ## [b]Returns:[/b][br]
 ## - [Array]: An array of log entries represented as strings.
@@ -412,7 +416,7 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 
 
 static func _is_mod_name_ignored(mod_name: String) -> bool:
-	if ignored_mods.size() == 0:
+	if ignored_mods.is_empty():
 		return false
 
 	if mod_name in ignored_mods:

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -94,10 +94,10 @@ var saved_extension_paths := {}
 
 var logged_messages: Dictionary:
 	set(val):
-		ModLoaderDeprecated.deprecated_message("ModLoaderStore.logged_messages was moved to ModLoaderLog.logged_messages", "7.0.1")
+		ModLoaderDeprecated.deprecated_changed("ModLoaderStore.logged_messages", "ModLoaderLog.logged_messages", "7.0.1")
 		ModLoaderLog.logged_messages = val
 	get:
-		ModLoaderDeprecated.deprecated_message("ModLoaderStore.logged_messages was moved to ModLoaderLog.logged_messages", "7.0.1")
+		ModLoaderDeprecated.deprecated_changed("ModLoaderStore.logged_messages", "ModLoaderLog.logged_messages", "7.0.1")
 		return ModLoaderLog.logged_messages
 
 # Active user profile

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -12,7 +12,7 @@ extends Node
 # Most of these settings should never need to change, aside from the DEBUG_*
 # options (which should be `false` when distributing compiled PCKs)
 
-const MODLOADER_VERSION := "7.0.0"
+const MODLOADER_VERSION := "7.0.1"
 
 # If true, a complete array of filepaths is stored for each mod. This is
 # disabled by default because the operation can be very expensive, but may
@@ -92,21 +92,13 @@ var saved_mod_mains := {}
 # Stores script extension paths with the key being the namespace of a mod
 var saved_extension_paths := {}
 
-# Keeps track of logged messages, to avoid flooding the log with duplicate notices
-# Can also be used by mods, eg. to create an in-game developer console that
-# shows messages
-var logged_messages := {
-	"all": {},
-	"by_mod": {},
-	"by_type": {
-		"fatal-error": {},
-		"error": {},
-		"warning": {},
-		"info": {},
-		"success": {},
-		"debug": {},
-	}
-}
+var logged_messages: Dictionary:
+	set(val):
+		ModLoaderDeprecated.deprecated_message("ModLoaderStore.logged_messages was moved to ModLoaderLog.logged_messages", "7.0.1")
+		ModLoaderLog.logged_messages = val
+	get:
+		ModLoaderDeprecated.deprecated_message("ModLoaderStore.logged_messages was moved to ModLoaderLog.logged_messages", "7.0.1")
+		return ModLoaderLog.logged_messages
 
 # Active user profile
 var current_user_profile: ModUserProfile
@@ -187,6 +179,20 @@ func _init():
 	_ModLoaderCache.init_cache(self)
 
 
+func set_option(option_name: String, new_value: Variant) -> void:
+	ml_options[option_name] = new_value
+
+	match option_name:
+		"log_level":
+			ModLoaderLog.verbosity = new_value
+		"ignored_mod_names_in_log":
+			ModLoaderLog.ignored_mods = new_value
+
+
+func get_option(option_name: String) -> Variant:
+	return ml_options[option_name]
+
+
 # Update ModLoader's options, via the custom options resource
 func _update_ml_options_from_options_resource() -> void:
 	# Path to the options resource
@@ -212,7 +218,7 @@ func _update_ml_options_from_options_resource() -> void:
 			), LOG_NAME)
 		# Update from the options in the resource
 		for key in ml_options:
-			ml_options[key] = current_options[key]
+			set_option(key, current_options[key])
 
 	# Get options overrides by feature tags
 	# An override is saved as Dictionary[String: ModLoaderOptionsProfile]
@@ -242,7 +248,7 @@ func _update_ml_options_from_options_resource() -> void:
 
 		# Update from the options in the resource
 		for key in ml_options:
-			ml_options[key] = override_options[key]
+			set_option(key, override_options[key])
 
 
 # Update ModLoader's options, via CLI args


### PR DESCRIPTION
Moves all logging variables from `ModLoaderStore` to `ModLoaderLog` - as static variables
also added `@tool` since there are a few cases popping up that make use of the logger in editor (like the mod tool)

that should also let us remove `is_silent` from a few functions like `is_name_or_namespace_valid` if we want to.

supersedes #456

works towards 
- #452