### PR TITLE
ci: :heavy_minus_sign: removed PR dependency check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_dependencies:
-    runs-on: ubuntu-latest
-    name: PR Dependency Check
-    steps:
-      - uses: gregsdennis/dependencies-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tests:
     name: "Running GUT tests on Godot 4.3"
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
Removed the PR dependency check.  
It caused numerous run errors and is not heavily used, so removing it is an efficient way to address the issue 😄