### PR TITLE
fix: :bug: continue if no `func_def` is found

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -101,8 +101,13 @@ func process_script(path: String, enable_hook_check := false) -> String:
 		while not is_top_level_func(source_code, func_def.get_start(), is_static): # indent before "func"
 			func_def = match_func_with_whitespace(method.name, source_code, func_def.get_end())
 			if not func_def or max_loop <= 0: # Couldn't match any func like before
-				break # Means invalid Script, should never happen
+				break 	# Means invalid Script, unless it's a child script.
+								# In such cases, the method name might be listed in the script_method_list
+								# but absent in the actual source_code.
 			max_loop -= 1
+
+		if not func_def: # If no valid function definition is found after processing.
+			continue # Skip to the next iteration.
 
 		var func_body_start_index := get_func_body_start_index(func_def.get_end(), source_code)
 		if func_body_start_index == -1: # The function is malformed, opening ( was not closed by )


### PR DESCRIPTION
If a parent class contains a method that is absent in a child class, it is possible for the script_method_list to include a method that is missing from the current script's source code. This fix prevents errors due to the missing `func_def`.

TODO: Add a test case for this.