### PR TITLE
fix: :bug: return detection

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -88,6 +88,7 @@ func process_script(path: String, enable_hook_check := false) -> String:
 			continue
 
 		var type_string := get_return_type_string(method.return)
+		var is_constructor: bool = method.name == "_init"
 		var is_static := true if method.flags == METHOD_FLAG_STATIC + METHOD_FLAG_NORMAL else false
 
 		var func_def: RegExMatch = match_func_with_whitespace(method.name, source_code)
@@ -132,6 +133,7 @@ func process_script(path: String, enable_hook_check := false) -> String:
 			method_arg_string_names_only,
 			method_arg_string_with_defaults_and_types,
 			type_string,
+			is_constructor,
 			is_static,
 			is_async,
 			hook_id,
@@ -345,6 +347,7 @@ static func build_mod_hook_string(
 	method_arg_string_names_only: String,
 	method_arg_string_with_defaults_and_types: String,
 	method_type: String,
+	is_constructor: bool,
 	is_static: bool,
 	is_async: bool,
 	hook_id: int,
@@ -352,6 +355,7 @@ static func build_mod_hook_string(
 	enable_hook_check := false,
 ) -> String:
 	var type_string := " -> %s" % method_type if not method_type.is_empty() else ""
+	var return_string := "return " if not is_constructor else ""
 	var static_string := "static " if is_static else ""
 	var await_string := "await " if is_async else ""
 	var async_string := "_async" if is_async else ""
@@ -363,7 +367,7 @@ static func build_mod_hook_string(
 
 	return """
 {STATIC}func {METHOD_NAME}({METHOD_PARAMS}){RETURN_TYPE_STRING}:
-	{HOOK_CHECK}return {AWAIT}_ModLoaderHooks.call_hooks{ASYNC}({METHOD_PREFIX}_{METHOD_NAME}, [{METHOD_ARGS}], {HOOK_ID}){HOOK_CHECK_ELSE}
+	{HOOK_CHECK}{RETURN}{AWAIT}_ModLoaderHooks.call_hooks{ASYNC}({METHOD_PREFIX}_{METHOD_NAME}, [{METHOD_ARGS}], {HOOK_ID}){HOOK_CHECK_ELSE}
 """.format({
 		"METHOD_PREFIX": method_prefix,
 		"METHOD_NAME": method_name,
@@ -371,6 +375,7 @@ static func build_mod_hook_string(
 		"RETURN_TYPE_STRING": type_string,
 		"METHOD_ARGS": method_arg_string_names_only,
 		"STATIC": static_string,
+		"RETURN": return_string,
 		"AWAIT": await_string,
 		"ASYNC": async_string,
 		"HOOK_ID": hook_id,

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -460,7 +460,7 @@ static func is_method_returning(func_body_string: String) -> bool:
 	var from := 0
 
 	while not found_return:
-		var found_index := func_body_string.find("return", from)
+		var found_index := func_body_string.find(" return ", from)
 		if found_index == -1:
 			# Break the loop if no return string was found
 			break

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -361,7 +361,7 @@ static func build_mod_hook_string(
 	var async_string := "_async" if is_async else ""
 	var hook_check := "if ModLoaderStore.any_mod_hooked:\n\t\t" if enable_hook_check else ""
 	var hook_check_else := get_hook_check_else_string(
-			await_string, method_prefix, method_name, method_arg_string_names_only
+			return_string, await_string, method_prefix, method_name, method_arg_string_names_only
 		) if enable_hook_check else ""
 
 
@@ -471,13 +471,15 @@ func collect_getters_and_setters(text: String) -> Dictionary:
 
 
 static func get_hook_check_else_string(
+	return_string: String,
 	await_string: String,
 	method_prefix: String,
 	method_name: String,
 	method_arg_string_names_only: String
 ) -> String:
-	return "\n\telse:\n\t\treturn {AWAIT}{METHOD_PREFIX}_{METHOD_NAME}({METHOD_ARGS})".format(
+	return "\n\telse:\n\t\t{RETURN}{AWAIT}{METHOD_PREFIX}_{METHOD_NAME}({METHOD_ARGS})".format(
 			{
+				"RETURN": return_string,
 				"AWAIT": await_string,
 				"METHOD_PREFIX": method_prefix,
 				"METHOD_NAME": method_name,

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -120,7 +120,6 @@ func process_script(path: String, enable_hook_check := false) -> String:
 		var is_async := is_func_async(func_body.get_string())
 		var method_arg_string_with_defaults_and_types := get_function_parameters(method.name, source_code, is_static)
 		var method_arg_string_names_only := get_function_arg_name_string(method.args)
-		var is_returning := is_method_returning(func_body.get_string())
 
 		var hook_id := _ModLoaderHooks.get_hook_hash(path, method.name)
 		var hook_id_data := [path, method.name, true]
@@ -133,7 +132,6 @@ func process_script(path: String, enable_hook_check := false) -> String:
 			method_arg_string_names_only,
 			method_arg_string_with_defaults_and_types,
 			type_string,
-			is_returning,
 			is_static,
 			is_async,
 			hook_id,


### PR DESCRIPTION
<details><summary>Old Description</summary>
<p>

The current return detection relies on data from `method_list`, but if a method does not have a statically typed return value, the `return_prop_usage == 131072` check does not appear to catch all return cases. This fix introduces `is_method_returning`, which checks the `func_body_string` for an uncommented `return`.

TODO:

- [x] Make sure the return string a single word
   - [x] without ignoring returns on the first or last line

</p>
</details> 

We can always return ?!
 - No 
![image](https://github.com/user-attachments/assets/b2d08bca-e139-4484-8bff-6ef41ea6cc2d)
- It seems we can always `return` except in `_init()`.