### PR TITLE
refactor: :recycle: demote error to info in `get_data()`

### DIFF
--- a/addons/mod_loader/internal/cache.gd
+++ b/addons/mod_loader/internal/cache.gd
@@ -31,7 +31,7 @@ static func add_data(key: String, data: Dictionary) -> Dictionary:
 # Get data from a specific key
 static func get_data(key: String) -> Dictionary:
 	if not ModLoaderStore.cache.has(key):
-		ModLoaderLog.error("key: \"%s\" not found in \"ModLoaderStore.cache\"" % key, LOG_NAME)
+		ModLoaderLog.info("key: \"%s\" not found in \"ModLoaderStore.cache\"" % key, LOG_NAME)
 		return {}
 
 	return ModLoaderStore.cache[key]


### PR DESCRIPTION
Demoted error log to info in `_ModLoaderCache.get_data()` to maintain parity with 4.x loader behavior.