### PR TITLE
fix: :bug: moved default profile creation to `_init()`

### DIFF
--- a/addons/mod_loader/api/profile.gd
+++ b/addons/mod_loader/api/profile.gd
@@ -199,6 +199,13 @@ static func get_all_as_array() -> Array:
 	return user_profiles
 
 
+# Returns true if the Mod User Profiles are initialized.
+# On the first execution of the game, user profiles might not yet be created.
+# Use this method to check if everything is ready to interact with the ModLoaderUserProfile API.
+static func is_initialized() -> bool:
+	return _ModLoaderFile.file_exists(FILE_PATH_USER_PROFILES)
+
+
 # Internal profile functions
 # =============================================================================
 

--- a/addons/mod_loader/resources/mod_data.gd
+++ b/addons/mod_loader/resources/mod_data.gd
@@ -107,7 +107,10 @@ func load_configs() -> void:
 		_load_config(config_file_path)
 
 	# Set the current_config based on the user profile
-	current_config = ModLoaderConfig.get_current_config(dir_name)
+	if ModLoaderUserProfile.is_initialized() and ModLoaderConfig.has_current_config(dir_name):
+		current_config = ModLoaderConfig.get_current_config(dir_name)
+	else:
+		current_config = ModLoaderConfig.get_config(dir_name, ModLoaderConfig.DEFAULT_CONFIG_NAME)
 
 
 # Create a new ModConfig instance for each Config JSON and add it to the configs dictionary.


### PR DESCRIPTION
Added `ModLoaderUserProfile.is_initialized()` and a fallback to the default config in `ModData.load_configs()`. Moved default user profile creation and user profile `mod_list` update to the mod loader `_init()`. With these changes, all config and user profile data is available on the first run.

closes #465 #468