### PR TITLE
feat: :sparkles: added `load_from_unpacked` option

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -194,7 +194,11 @@ static func get_mod_paths_from_all_sources() -> Array[String]:
 	var mod_paths: Array[String] = []
 
 	var mod_dirs := get_dir_paths_in_dir(get_unpacked_mods_dir_path())
-	mod_paths.append_array(mod_dirs)
+
+	if ModLoaderStore.has_feature.editor or ModLoaderStore.ml_options.load_from_unpacked:
+		mod_paths.append_array(mod_dirs)
+	else:
+		ModLoaderLog.info("Loading mods from \"res://mods-unpacked\" is disabled.", LOG_NAME)
 
 	if ModLoaderStore.ml_options.load_from_local:
 		var mods_dir := get_path_to_mods()

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -80,6 +80,10 @@ func _init() -> void:
 	for mod_path in mod_paths:
 		var is_zip := _ModLoaderPath.is_zip(mod_path)
 
+		if not is_in_editor and not ModLoaderStore.ml_options.load_from_unpacked:
+			ModLoaderLog.debug("The mod from path \"%s\" is not loaded because loading from mods-unpacked has been disabled in the options." % mod_path, LOG_NAME)
+			continue
+
 		# Load manifest file
 		var manifest_data: Dictionary = _ModLoaderFile.load_manifest_file(mod_path)
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -30,8 +30,6 @@ signal new_hooks_created
 
 const LOG_NAME := "ModLoader"
 
-var is_in_editor := OS.has_feature("editor")
-
 
 func _init() -> void:
 	# if mods are not enabled - don't load mods
@@ -41,7 +39,7 @@ func _init() -> void:
 	# Only load the hook pack if not in the editor
 	# We can't use it in the editor - see https://github.com/godotengine/godot/issues/19815
 	# Mod devs can use the Dev Tool to generate hooks in the editor.
-	if not is_in_editor and _ModLoaderFile.file_exists(_ModLoaderPath.get_path_to_hook_pack()):
+	if not ModLoaderStore.has_feature.editor and _ModLoaderFile.file_exists(_ModLoaderPath.get_path_to_hook_pack()):
 		_load_mod_hooks_pack()
 
 	# Rotate the log files once on startup.
@@ -79,10 +77,6 @@ func _init() -> void:
 
 	for mod_path in mod_paths:
 		var is_zip := _ModLoaderPath.is_zip(mod_path)
-
-		if not is_zip and not is_in_editor and not ModLoaderStore.ml_options.load_from_unpacked:
-			ModLoaderLog.debug("The mod from path \"%s\" is not loaded because loading from mods-unpacked has been disabled in the options." % mod_path, LOG_NAME)
-			continue
 
 		# Load manifest file
 		var manifest_data: Dictionary = _ModLoaderFile.load_manifest_file(mod_path)
@@ -123,7 +117,7 @@ func _init() -> void:
 				# "don't use ZIPs with unpacked mods!"
 				# https://github.com/godotengine/godot/issues/19815
 				# https://github.com/godotengine/godot/issues/16798
-				if is_in_editor:
+				if ModLoaderStore.has_feature.editor:
 					ModLoaderLog.hint(
 						"Loading any resource packs (.zip/.pck) with `load_resource_pack` will WIPE the entire virtual res:// directory. " +
 						"If you have any unpacked mods in %s, they will not be loaded.Please unpack your mod ZIPs instead, and add them to %s" %

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -80,7 +80,7 @@ func _init() -> void:
 	for mod_path in mod_paths:
 		var is_zip := _ModLoaderPath.is_zip(mod_path)
 
-		if not is_in_editor and not ModLoaderStore.ml_options.load_from_unpacked:
+		if not is_zip and not is_in_editor and not ModLoaderStore.ml_options.load_from_unpacked:
 			ModLoaderLog.debug("The mod from path \"%s\" is not loaded because loading from mods-unpacked has been disabled in the options." % mod_path, LOG_NAME)
 			continue
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -111,6 +111,9 @@ var cache := {}
 # See: res://addons/mod_loader/resources/options_profile.gd
 var ml_options: ModLoaderOptionsProfile
 
+var has_feature := {
+	"editor" = OS.has_feature("editor")
+}
 
 # Methods
 # =============================================================================

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -74,6 +74,12 @@ enum VERSION_VALIDATION {
 @export var load_from_steam_workshop: bool = false
 ## Indicates whether to load mods from the "mods" folder located at the game's install directory, or the overridden mods path.
 @export var load_from_local: bool = true
+## Indicates whether to load mods from  [code]"res://mods-unpacked"[/code] in the exported game.[br]
+## ===[br]
+## [b]Note:[color=note "Load from unpacked in the editor"][/color][/b][br]
+## In the editor, mods inside [code]"res://mods-unpacked"[/code] are always loaded. Use [member enable_mods] to disable mod loading completely.[br]
+## ===[br]
+@export var load_from_unpacked: bool = true
 ## Path to a folder containing mods [br]
 ## Mod zips should be directly in this folder
 @export_dir var override_path_to_mods = ""


### PR DESCRIPTION
Added the `load_from_unpacked` mod source option.  

Allows the option to disable or enable loading mods from `res://mods-unpacked` in the exported game.

closes #442