### PR TITLE
fix: :bug: use `reader.get_files().has()` before 4.2

### DIFF
--- a/addons/mod_loader/internal/file.gd
+++ b/addons/mod_loader/internal/file.gd
@@ -194,7 +194,11 @@ static func file_exists_in_zip(zip_path: String, path: String) -> bool:
 	var reader := zip_reader_open(zip_path)
 	if not reader:
 		return false
-	return reader.file_exists(path.trim_prefix("res://"))
+
+	if _ModLoaderGodot.is_version_below(_ModLoaderGodot.ENGINE_VERSION_HEX_4_2_0):
+		return reader.get_files().has(path.trim_prefix("res://"))
+	else:
+		return reader.file_exists(path.trim_prefix("res://"))
 
 
 static func get_mod_dir_name_in_zip(zip_path: String) -> String:

--- a/addons/mod_loader/internal/godot.gd
+++ b/addons/mod_loader/internal/godot.gd
@@ -1,3 +1,4 @@
+@tool
 class_name _ModLoaderGodot
 extends Object
 
@@ -7,6 +8,11 @@ extends Object
 
 const LOG_NAME := "ModLoader:Godot"
 const AUTOLOAD_CONFIG_HELP_MSG := "To configure your autoloads, go to Project > Project Settings > Autoload."
+
+const ENGINE_VERSION_HEX_4_2_2 := 0x040202
+const ENGINE_VERSION_HEX_4_2_0 := 0x040200
+
+static var engine_version_hex: int = Engine.get_version_info().hex
 
 
 # Check autoload positions:
@@ -100,3 +106,11 @@ static func get_autoload_index(autoload_name: String) -> int:
 	var autoload_index := autoloads.find(autoload_name)
 
 	return autoload_index
+
+
+static func is_version_below(version_hex: int) -> bool:
+	return engine_version_hex < version_hex
+
+
+static func is_version_above(version_hex: int) -> bool:
+	return engine_version_hex > version_hex

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -14,15 +14,12 @@ const HASH_COLLISION_ERROR := \
 	"MODDING HOOKS ERROR: Hash collision between %s and %s. The collision can be resolved by renaming one of the methods or changing their script's path."
 const MOD_LOADER_HOOKS_START_STRING := \
 	"\n# ModLoader Hooks - The following code has been automatically added by the Godot Mod Loader."
-const ENGINE_VERSION_HEX_4_2_2 := 0x040202
 
 ## \\bfunc\\b\\s+		->	Match the word 'func' and one or more whitespace characters
 ## \\b%s\\b 			->	the function name
 ## (?:.*\\n*)*?\\s*\\( 	->	Match any character between zero and unlimited times, but be lazy
 ## 							and only do this until a '(' is found.
 const REGEX_MATCH_FUNC_WITH_WHITESPACE := "\\bfunc\\b\\s+\\b%s\\b(?:.*\\n*)*?\\s*\\("
-
-static var engine_version_hex: int = Engine.get_version_info().hex
 
 ## finds function names used as setters and getters (excluding inline definitions)
 ## group 2 and 4 contain the setter/getter names
@@ -337,7 +334,7 @@ func edit_vanilla_method(
 
 
 func fix_method_super(method_name: String, func_body: RegExMatch, text: String) -> String:
-	if engine_version_hex < ENGINE_VERSION_HEX_4_2_2:
+	if _ModLoaderGodot.is_version_below(_ModLoaderGodot.ENGINE_VERSION_HEX_4_2_2):
 		return fix_method_super_before_4_2_2(method_name, func_body, text)
 
 	return regex_super_call.sub(


### PR DESCRIPTION
Moved engine version-related functionality to `_ModLoaderGodot` and added `@tool` to `_ModLoaderGodot` to allow access in the editor. Added a version check to `_ModLoaderFile.file_exists_in_zip()` because `ZIPReader.file_exists()` was introduced in Godot 4.2.