### PR TITLE
Add check to see if GodotPCKExplorer executable is present before attempting injection

### DIFF
--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -69,6 +69,13 @@ func setup_modloader() -> void:
 	if is_setup_create_override_cfg:
 		handle_override_cfg()
 	else:
+		# If GodotPCKExplorer executable doesn't exist, we can't continue
+		if not FileAccess.file_exists(path.pck_explorer):
+			ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
+			OS.alert(
+					"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
+			)
+			pck_explorer_not_found = true
 		handle_injection()
 
 	# ModLoader is set up. A game restart is required to apply the ProjectSettings.
@@ -78,6 +85,9 @@ func setup_modloader() -> void:
 		# If the --only-setup cli argument is passed, quit with exit code 0
 		is_only_setup:
 			quit(0)
+		# If GodotPCKExplorer executable doesn't exist, quit with exit code 1
+		pck_explorer_not_found:
+			quit(1)
 		# If no cli argument is passed, show message with OS.alert() and user has to restart the game
 		_:
 			OS.alert(

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -19,6 +19,7 @@ var is_only_setup: bool = ModLoaderSetupUtils.is_running_with_command_line_arg("
 var is_setup_create_override_cfg: bool = ModLoaderSetupUtils.is_running_with_command_line_arg(
 	"--setup-create-override-cfg"
 )
+var pck_explorer_not_found: bool = false
 
 
 func _init() -> void:
@@ -69,13 +70,6 @@ func setup_modloader() -> void:
 	if is_setup_create_override_cfg:
 		handle_override_cfg()
 	else:
-		# If GodotPCKExplorer executable doesn't exist, we can't continue
-		if not FileAccess.file_exists(path.pck_explorer):
-			ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
-			OS.alert(
-					"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
-			)
-			pck_explorer_not_found = true
 		handle_injection()
 
 	# ModLoader is set up. A game restart is required to apply the ProjectSettings.
@@ -155,6 +149,15 @@ func handle_override_cfg() -> void:
 
 # Creates the project.binary file, adds it to the pck and removes the no longer needed project.binary file.
 func handle_injection() -> void:
+	# If GodotPCKExplorer executable doesn't exist, we can't continue
+		if not FileAccess.file_exists(path.pck_explorer):
+			ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
+			OS.alert(
+					"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
+			)
+			pck_explorer_not_found = true
+			return
+
 	ModLoaderSetupLog.debug("Start injection", LOG_NAME)
 	# Create temp dir
 	ModLoaderSetupLog.debug('Creating temp dir at "%s"' % path.temp_dir_path, LOG_NAME)
@@ -289,6 +292,7 @@ func setup_file_data() -> void:
 		path.temp_dir_path
 		+ "/.godot/global_script_class_cache.cfg"
 	)
+
 	# can be supplied to override the exe_name
 	file_name.cli_arg_exe = ModLoaderSetupUtils.get_cmd_line_arg_value("--exe-name")
 	# can be supplied to override the pck_name

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -19,6 +19,7 @@ var is_only_setup: bool = ModLoaderSetupUtils.is_running_with_command_line_arg("
 var is_setup_create_override_cfg: bool = ModLoaderSetupUtils.is_running_with_command_line_arg(
 	"--setup-create-override-cfg"
 )
+var pck_explorer_not_found: bool = false
 
 
 func _init() -> void:
@@ -78,6 +79,9 @@ func setup_modloader() -> void:
 		# If the --only-setup cli argument is passed, quit with exit code 0
 		is_only_setup:
 			quit(0)
+		# If GodotPCKExplorer executable doesn't exist, quit with exit code 1
+		pck_explorer_not_found:
+			quit(1)
 		# If no cli argument is passed, show message with OS.alert() and user has to restart the game
 		_:
 			OS.alert(
@@ -145,6 +149,15 @@ func handle_override_cfg() -> void:
 
 # Creates the project.binary file, adds it to the pck and removes the no longer needed project.binary file.
 func handle_injection() -> void:
+	# If GodotPCKExplorer executable doesn't exist, we can't continue
+	if not FileAccess.file_exists(path.pck_explorer):
+		ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
+		OS.alert(
+				"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
+		)
+		pck_explorer_not_found = true
+		return
+
 	ModLoaderSetupLog.debug("Start injection", LOG_NAME)
 	# Create temp dir
 	ModLoaderSetupLog.debug('Creating temp dir at "%s"' % path.temp_dir_path, LOG_NAME)

--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -150,13 +150,13 @@ func handle_override_cfg() -> void:
 # Creates the project.binary file, adds it to the pck and removes the no longer needed project.binary file.
 func handle_injection() -> void:
 	# If GodotPCKExplorer executable doesn't exist, we can't continue
-		if not FileAccess.file_exists(path.pck_explorer):
-			ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
-			OS.alert(
-					"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
-			)
-			pck_explorer_not_found = true
-			return
+	if not FileAccess.file_exists(path.pck_explorer):
+		ModLoaderSetupLog.error("GodotPCKExplorer executable isn't present, cannot continue with injection", LOG_NAME)
+		OS.alert(
+				"The GodotPCKExplorer executable isn't present under addons/mod_loader/vendor/GodotPCKExplorer, cannot inject ModLoader into pck file"
+		)
+		pck_explorer_not_found = true
+		return
 
 	ModLoaderSetupLog.debug("Start injection", LOG_NAME)
 	# Create temp dir


### PR DESCRIPTION
Was having a hard time figuring out why the Mod Loader setup script wasn't creating a copy of the main pck file, the reason was because the script just assumes the GodotPCKExplorer executable exists.
If it doesn't exist, it just assumes it worked and continues on.

This pull request just adds a check to see if the executable exists, I tried to add this under handle_injection(), but was having issues with it not exiting properly.
Please make changes to the wording of the error or the location of the check if needed.