### PR TITLE
use `rich_print` when in-editor

### DIFF
--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -47,7 +47,6 @@ static var ignored_mods: Array[String] = []
 static var warning_color := Color("#ffde66")
 static var success_color := Color("#5d8c3f")
 static var info_color := Color("#70bafa")
-static var debug_color := Color("#00000000")
 static var hint_color := Color("#b293fa")
 
 ## This Sub-Class represents a log entry in ModLoader.
@@ -450,7 +449,7 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 				_write_to_log_file(log_entry.get_entry())
 		"debug":
 			if verbosity >= VERBOSITY_LEVEL.DEBUG:
-				_print_rich("", log_entry.get_prefix() + message, debug_color)
+				print(log_entry.get_prefix() + message)
 				_write_to_log_file(log_entry.get_entry())
 		"hint":
 			if OS.has_feature("editor") and verbosity >= VERBOSITY_LEVEL.DEBUG:

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -43,7 +43,11 @@ static var verbosity: VERBOSITY_LEVEL = VERBOSITY_LEVEL.DEBUG
 ## Array of mods that should be ignored when logging messages (contains mod IDs as strings)
 static var ignored_mods: Array[String] = []
 
-## Highlighting color for hint type log messages
+# TODO: use options profile here instead of hard coding
+static var warning_color := Color("#ffff00")
+static var success_color := Color("#008000")
+static var info_color := Color("#4169e1")
+static var debug_color := Color("#ffffff")
 static var hint_color := Color("#70bafa")
 
 ## This Sub-Class represents a log entry in ModLoader.
@@ -391,6 +395,12 @@ static func get_all_entries_as_string(log_entries: Array) -> Array:
 # Internal log functions
 # =============================================================================
 
+static func _print_rich(prefix: String, message: String, color: String):
+	if OS.has_feature("editor"):
+		print_rich("[color=%s][b]%s[/b][/color]%s" % [color, prefix, message])
+	else:
+		print(prefix + message)
+
 static func _log(message: String, mod_name: String, log_type: String = "info", only_once := false) -> void:
 	if _is_mod_name_ignored(mod_name):
 		return
@@ -427,20 +437,24 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 			_write_to_log_file(log_entry.get_entry())
 		"warning":
 			if verbosity >= VERBOSITY_LEVEL.WARNING:
-				print(log_entry.get_prefix() + message)
+				_print_rich(log_entry.get_prefix(), message, warning_color.to_html(false))
 				push_warning(message)
 				_write_to_log_file(log_entry.get_entry())
-		"info", "success":
+		"success":
 			if verbosity >= VERBOSITY_LEVEL.INFO:
-				print(log_entry.get_prefix() + message)
+				_print_rich(log_entry.get_prefix(), message, success_color.to_html(false))
+				_write_to_log_file(log_entry.get_entry())
+		"info":
+			if verbosity >= VERBOSITY_LEVEL.INFO:
+				_print_rich(log_entry.get_prefix(), message, info_color.to_html(false))
 				_write_to_log_file(log_entry.get_entry())
 		"debug":
 			if verbosity >= VERBOSITY_LEVEL.DEBUG:
-				print(log_entry.get_prefix() + message)
+				_print_rich(log_entry.get_prefix(), message, debug_color.to_html(false))
 				_write_to_log_file(log_entry.get_entry())
 		"hint":
 			if OS.has_feature("editor") and verbosity >= VERBOSITY_LEVEL.DEBUG:
-				print_rich("[color=%s]%s[/color]" % [hint_color.to_html(false), log_entry.get_prefix() + message])
+				_print_rich(log_entry.get_prefix(), message, hint_color.to_html(false))
 
 
 static func _is_mod_name_ignored(mod_name: String) -> bool:

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -48,6 +48,8 @@ static var warning_color := Color("#ffde66")
 static var success_color := Color("#5d8c3f")
 static var info_color := Color("#70bafa")
 static var hint_color := Color("#b293fa")
+static var debug_color := Color("#d4d4d4")
+static var debug_bold := true
 
 ## This Sub-Class represents a log entry in ModLoader.
 class ModLoaderLogEntry:
@@ -400,9 +402,14 @@ static func get_all_entries_as_string(log_entries: Array) -> Array:
 # Internal log functions
 # =============================================================================
 
-static func _print_rich(prefix: String, message: String, color: Color):
+static func _print_rich(prefix: String, message: String, color: Color, bold := true):
 	if OS.has_feature("editor"):
-		print_rich("[color=%s][b]%s[/b][/color]%s" % [color.to_html(false), prefix, message])
+		var prefix_text := "[b]%s[/b]" % prefix if bold else prefix
+		print_rich("[color=%s]%s[/color]%s" % [
+			color.to_html(false),
+			prefix_text,
+			message
+		])
 	else:
 		print(prefix + message)
 
@@ -458,7 +465,7 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 				_write_to_log_file(log_entry.get_entry())
 		"debug":
 			if verbosity >= VERBOSITY_LEVEL.DEBUG:
-				print(log_entry.get_prefix() + message)
+				_print_rich(log_entry.get_prefix(), message, debug_color, debug_bold)
 				_write_to_log_file(log_entry.get_entry())
 		"hint":
 			if OS.has_feature("editor") and verbosity >= VERBOSITY_LEVEL.DEBUG:

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -44,11 +44,11 @@ static var verbosity: VERBOSITY_LEVEL = VERBOSITY_LEVEL.DEBUG
 static var ignored_mods: Array[String] = []
 
 # NOTE: default values which get replaced later by `_configure_logger`
-static var warning_color := Color("#ffff00")
-static var success_color := Color("#008000")
-static var info_color := Color("#4169e1")
-static var debug_color := Color("#ffffff")
-static var hint_color := Color("#70bafa")
+static var warning_color := Color("#ffde66")
+static var success_color := Color("#5d8c3f")
+static var info_color := Color("#70bafa")
+static var debug_color := Color("#00000000")
+static var hint_color := Color("#b293fa")
 
 ## This Sub-Class represents a log entry in ModLoader.
 class ModLoaderLogEntry:
@@ -450,7 +450,7 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 				_write_to_log_file(log_entry.get_entry())
 		"debug":
 			if verbosity >= VERBOSITY_LEVEL.DEBUG:
-				_print_rich(log_entry.get_prefix(), message, debug_color)
+				_print_rich("", log_entry.get_prefix() + message, debug_color)
 				_write_to_log_file(log_entry.get_entry())
 		"hint":
 			if OS.has_feature("editor") and verbosity >= VERBOSITY_LEVEL.DEBUG:

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -102,9 +102,15 @@ class ModLoaderLogEntry:
 
 	## Get the prefix string for the log entry, including the log type and mod name.[br]
 	## [br]
+	## [b]Parameters:[/b][br]
+	## [param exclude_type] ([bool]): (Optional) If true, the log type (e.g., DEBUG, WARN) will be excluded from the prefix. Default is false.[br]
+	## [br]
 	## [b]Returns:[/b] [String]
-	func get_prefix() -> String:
-		return "%s %s: " % [type.to_upper(), mod_name]
+	func get_prefix(exclude_type: bool = false) -> String:
+		return "%s%s: " % [
+			"" if exclude_type else type.to_upper() + " ",
+			mod_name
+		]
 
 
 	## Generate an MD5 hash of the log entry (prefix + message).[br]
@@ -431,7 +437,10 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 			_write_to_log_file(JSON.stringify(get_stack(), "  "))
 			assert(false, message)
 		"error":
-			printerr(log_entry.get_prefix() + message)
+			if OS.has_feature("editor"):
+				printerr(log_entry.get_prefix(true) + message)
+			else:
+				printerr(log_entry.get_prefix() + message)
 			push_error(message)
 			_write_to_log_file(log_entry.get_entry())
 		"warning":

--- a/addons/mod_loader/api/log.gd
+++ b/addons/mod_loader/api/log.gd
@@ -43,7 +43,7 @@ static var verbosity: VERBOSITY_LEVEL = VERBOSITY_LEVEL.DEBUG
 ## Array of mods that should be ignored when logging messages (contains mod IDs as strings)
 static var ignored_mods: Array[String] = []
 
-# TODO: use options profile here instead of hard coding
+# NOTE: default values which get replaced later by `_configure_logger`
 static var warning_color := Color("#ffff00")
 static var success_color := Color("#008000")
 static var info_color := Color("#4169e1")
@@ -395,9 +395,9 @@ static func get_all_entries_as_string(log_entries: Array) -> Array:
 # Internal log functions
 # =============================================================================
 
-static func _print_rich(prefix: String, message: String, color: String):
+static func _print_rich(prefix: String, message: String, color: Color):
 	if OS.has_feature("editor"):
-		print_rich("[color=%s][b]%s[/b][/color]%s" % [color, prefix, message])
+		print_rich("[color=%s][b]%s[/b][/color]%s" % [color.to_html(false), prefix, message])
 	else:
 		print(prefix + message)
 
@@ -437,24 +437,24 @@ static func _log(message: String, mod_name: String, log_type: String = "info", o
 			_write_to_log_file(log_entry.get_entry())
 		"warning":
 			if verbosity >= VERBOSITY_LEVEL.WARNING:
-				_print_rich(log_entry.get_prefix(), message, warning_color.to_html(false))
+				_print_rich(log_entry.get_prefix(), message, warning_color)
 				push_warning(message)
 				_write_to_log_file(log_entry.get_entry())
 		"success":
 			if verbosity >= VERBOSITY_LEVEL.INFO:
-				_print_rich(log_entry.get_prefix(), message, success_color.to_html(false))
+				_print_rich(log_entry.get_prefix(), message, success_color)
 				_write_to_log_file(log_entry.get_entry())
 		"info":
 			if verbosity >= VERBOSITY_LEVEL.INFO:
-				_print_rich(log_entry.get_prefix(), message, info_color.to_html(false))
+				_print_rich(log_entry.get_prefix(), message, info_color)
 				_write_to_log_file(log_entry.get_entry())
 		"debug":
 			if verbosity >= VERBOSITY_LEVEL.DEBUG:
-				_print_rich(log_entry.get_prefix(), message, debug_color.to_html(false))
+				_print_rich(log_entry.get_prefix(), message, debug_color)
 				_write_to_log_file(log_entry.get_entry())
 		"hint":
 			if OS.has_feature("editor") and verbosity >= VERBOSITY_LEVEL.DEBUG:
-				_print_rich(log_entry.get_prefix(), message, hint_color.to_html(false))
+				_print_rich(log_entry.get_prefix(), message, hint_color)
 
 
 static func _is_mod_name_ignored(mod_name: String) -> bool:

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -231,3 +231,5 @@ func _configure_logger() -> void:
 	ModLoaderLog.success_color = ml_options.success_color
 	ModLoaderLog.info_color = ml_options.info_color
 	ModLoaderLog.hint_color = ml_options.hint_color
+	ModLoaderLog.debug_color = ml_options.debug_color
+	ModLoaderLog.debug_bold = ml_options.debug_bold

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -230,5 +230,4 @@ func _configure_logger() -> void:
 	ModLoaderLog.warning_color = ml_options.warning_color
 	ModLoaderLog.success_color = ml_options.success_color
 	ModLoaderLog.info_color = ml_options.info_color
-	ModLoaderLog.debug_color = ml_options.debug_color
 	ModLoaderLog.hint_color = ml_options.hint_color

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -227,4 +227,8 @@ func _update_ml_options_from_cli_args() -> void:
 func _configure_logger() -> void:
 	ModLoaderLog.verbosity = ml_options.log_level
 	ModLoaderLog.ignored_mods = ml_options.ignored_mod_names_in_log
+	ModLoaderLog.warning_color = ml_options.warning_color
+	ModLoaderLog.success_color = ml_options.success_color
+	ModLoaderLog.info_color = ml_options.info_color
+	ModLoaderLog.debug_color = ml_options.debug_color
 	ModLoaderLog.hint_color = ml_options.hint_color

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -61,8 +61,6 @@ enum VERSION_VALIDATION {
 @export var success_color := Color("#5d8c3f")
 ## Highlighting color for info type log messages
 @export var info_color := Color("#70bafa")
-## Highlighting color for debug type log messages
-@export var debug_color := Color("#00000000")
 ## Highlighting color for hint type log messages
 @export var hint_color := Color("#b293fa")
 

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -63,6 +63,10 @@ enum VERSION_VALIDATION {
 @export var info_color := Color("#70bafa")
 ## Highlighting color for hint type log messages
 @export var hint_color := Color("#b293fa")
+## Highlighting color for debug type log messages
+@export var debug_color := Color("#d4d4d4")
+## Highlight debug log prefixes with bold formatting
+@export var debug_bold := true
 
 @export_group("Game Data")
 ## Steam app id, can be found in the steam page url

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -56,15 +56,15 @@ enum VERSION_VALIDATION {
 ## [code]ModLoader:*[/code] - ignore all beginning with this name [br]
 @export var ignored_mod_names_in_log: Array[String] = []
 ## Highlighting color for warning type log messages
-@export var warning_color := Color("#ffff00")
+@export var warning_color := Color("#ffde66")
 ## Highlighting color for success type log messages
-@export var success_color := Color("#008000")
+@export var success_color := Color("#5d8c3f")
 ## Highlighting color for info type log messages
-@export var info_color := Color("#4169e1")
+@export var info_color := Color("#70bafa")
 ## Highlighting color for debug type log messages
-@export var debug_color := Color("#ffffff")
+@export var debug_color := Color("#00000000")
 ## Highlighting color for hint type log messages
-@export var hint_color := Color("#70bafa")
+@export var hint_color := Color("#b293fa")
 
 @export_group("Game Data")
 ## Steam app id, can be found in the steam page url

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -55,6 +55,15 @@ enum VERSION_VALIDATION {
 ## [code]ModLoader:Dependency[/code] - ignore the exact name [br]
 ## [code]ModLoader:*[/code] - ignore all beginning with this name [br]
 @export var ignored_mod_names_in_log: Array[String] = []
+## Highlighting color for warning type log messages
+@export var warning_color := Color("#ffff00")
+## Highlighting color for success type log messages
+@export var success_color := Color("#008000")
+## Highlighting color for info type log messages
+@export var info_color := Color("#4169e1")
+## Highlighting color for debug type log messages
+@export var debug_color := Color("#ffffff")
+## Highlighting color for hint type log messages
 @export var hint_color := Color("#70bafa")
 
 @export_group("Game Data")


### PR DESCRIPTION
Allows for a much cleaner separation of the logs. This PR introduces scaffolding for the options profile. Similar to how `hint_color` currently is. Works towards https://github.com/GodotModding/godot-mod-loader/issues/450
BEFORE | AFTER
:-:|:-:
![](https://github.com/user-attachments/assets/fa952a42-284b-43df-8685-5edd419178db)  |  ![](https://github.com/user-attachments/assets/dc99c67e-a20c-4b95-9738-843a7def03b2)