### PR TITLE
chore: export ignore icon.png.import

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@ addons/mod_loader/vendor/               export-ignore
 addons/mod_loader/mod_loader_setup.gd   export-ignore
 
 # Used during docs generation, but not relevant for addon users 
-project.godot							export-ignore
-main.tscn								export-ignore
-icon.png								export-ignore
+project.godot                           export-ignore
+main.tscn                               export-ignore
+icon.png                                export-ignore
+icon.png.import                         export-ignore


### PR DESCRIPTION
Added `icon.png.import` to `export-ignore`, stops it from being downloaded on asset lib installs.