### PR TITLE
fix: incorrect paths in new_global_classes

### DIFF
--- a/addons/mod_loader/mod_loader_setup.gd
+++ b/addons/mod_loader/mod_loader_setup.gd
@@ -19,7 +19,7 @@ const new_global_classes := [
 		"base": "Node",
 		"class": "ModLoaderUtils",
 		"language": "GDScript",
-		"path": "res://addons/mod_loader/mod_loader_utils.gd"
+		"path": "res://addons/mod_loader/internal/mod_loader_utils.gd"
 	}, {
 		"base": "Resource",
 		"class": "ModManifest",
@@ -59,12 +59,12 @@ const new_global_classes := [
 		"base": "Object",
 		"class": "_ModLoaderGodot",
 		"language": "GDScript",
-		"path": "res://addons/mod_loader/api/godot.gd"
+		"path": "res://addons/mod_loader/internal/godot.gd"
 	}, {
 		"base": "Node",
 		"class": "_ModLoaderSteam",
 		"language": "GDScript",
-		"path": "res://addons/mod_loader/api/third_party/steam.gd"
+		"path": "res://addons/mod_loader/internal/third_party/steam.gd"
 	}, {
 		"base": "Node",
 		"class": "ModLoaderLog",


### PR DESCRIPTION
See title. Certain paths are seemingly outdated. Had to edit these myself for the self-install to work.