### PR TITLE
feat: :sparkles: steam workshop data

### DIFF
--- a/addons/mod_loader/internal/mod_loader_utils.gd
+++ b/addons/mod_loader/internal/mod_loader_utils.gd
@@ -23,6 +23,14 @@ static func get_string_from_dict(dict: Dictionary, key: String) -> String:
 	return dict[key]
 
 
+# Returns -1 if the key does not exist or is not type of int
+static func get_int_from_dict(dict: Dictionary, key: String) -> int:
+	if not dict.has(key):
+		return -1
+
+	return int(dict[key])
+
+
 # Returns an empty Array if the key does not exist or is not type of Array
 static func get_array_from_dict(dict: Dictionary, key: String) -> Array:
 	if not dict.has(key):

--- a/addons/mod_loader/resources/mod_manifest.gd
+++ b/addons/mod_loader/resources/mod_manifest.gd
@@ -34,6 +34,7 @@ var tags : PoolStringArray = []
 var config_schema := {}
 var description_rich := ""
 var image: StreamTexture
+var steam_workshop_id: int = -1
 
 
 # Required keys in a mod's manifest.json file
@@ -144,6 +145,10 @@ func _init(manifest: Dictionary) -> void:
 	):
 		return
 
+	if manifest.extra.has("steam"):
+		# Not validated for now
+		steam_workshop_id = ModLoaderUtils.get_int_from_dict(manifest.extra.steam, "workshop_id")
+
 
 # Mod ID used in the mod loader
 # Format: {namespace}-{name}
@@ -176,6 +181,7 @@ func get_as_dict() -> Dictionary:
 		"config_schema": config_schema,
 		"description_rich": description_rich,
 		"image": image,
+		"steam_workshop_id": steam_workshop_id
 	}
 
 
@@ -200,6 +206,9 @@ func to_json() -> String:
 				"config_schema": config_schema,
 				"description_rich": description_rich,
 				"image": image,
+			},
+			"steam": {
+				"workshop_id": steam_workshop_id
 			}
 		}
 	}, "\t")

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -1,9 +1,6 @@
 class_name ModLoaderOptionsProfile
 extends Resource
 
-# export (String) var my_string := ""
-# export (Resource) var upgrade_to_process_icon = null
-# export (Array, Resource) var elites: = []
 
 export (bool) var enable_mods = true
 export (Array, String) var locked_mods = []
@@ -11,6 +8,7 @@ export (ModLoaderLog.VERBOSITY_LEVEL) var log_level := ModLoaderLog.VERBOSITY_LE
 export (Array, String) var disabled_mods = []
 export (bool) var allow_modloader_autoloads_anywhere = false
 export (bool) var steam_workshop_enabled = false
+export (Array, String) var steam_workshop_tags = []
 export (String, DIR) var override_path_to_mods = ""
 export (String, DIR) var override_path_to_configs = ""
 export (String, DIR) var override_path_to_workshop = ""


### PR DESCRIPTION
- Added `steam_workshop_id` to the manifest.
  - This can be used to link a local mod to a Steam Workshop item.
- Added `steam_workshop_tags` to `ModLoaderOptionsProfile`.
   - This can be used by the game developer to define a selection of tags for mod developers to set when uploading their mod.
