### PR TITLE
refactor: :recycle: allow loading mods from "mods" dir and steam workshop

### DIFF
--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -232,16 +232,18 @@ func _check_autoload_positions() -> void:
 func _load_mod_zips() -> Dictionary:
 	var zip_data := {}
 
-	if not ModLoaderStore.ml_options.steam_workshop_enabled:
+	if ModLoaderStore.ml_options.steam_workshop_enabled:
+		# If we're using Steam workshop, loop over the workshop item directories
+		var loaded_workshop_zip_data := _ModLoaderSteam.load_steam_workshop_zips()
+		zip_data.merge(loaded_workshop_zip_data)
+
+	if ModLoaderStore.ml_options.load_from_local:
 		var mods_folder_path := _ModLoaderPath.get_path_to_mods()
 
 		# If we're not using Steam workshop, just loop over the mod ZIPs.
 		var loaded_zip_data := _ModLoaderFile.load_zips_in_folder(mods_folder_path)
 		zip_data.merge(loaded_zip_data)
-	else:
-		# If we're using Steam workshop, loop over the workshop item directories
-		var loaded_workshop_zip_data := _ModLoaderSteam.load_steam_workshop_zips()
-		zip_data.merge(loaded_workshop_zip_data)
+
 
 	return zip_data
 

--- a/addons/mod_loader/mod_loader.gd
+++ b/addons/mod_loader/mod_loader.gd
@@ -239,11 +239,8 @@ func _load_mod_zips() -> Dictionary:
 
 	if ModLoaderStore.ml_options.load_from_local:
 		var mods_folder_path := _ModLoaderPath.get_path_to_mods()
-
-		# If we're not using Steam workshop, just loop over the mod ZIPs.
 		var loaded_zip_data := _ModLoaderFile.load_zips_in_folder(mods_folder_path)
 		zip_data.merge(loaded_zip_data)
-
 
 	return zip_data
 

--- a/addons/mod_loader/mod_loader_store.gd
+++ b/addons/mod_loader/mod_loader_store.gd
@@ -113,6 +113,9 @@ var ml_options := {
 	# instead of the default location (res://mods)
 	steam_workshop_enabled = false,
 
+	# Indicates whether to load mods from the "mods" folder located at the game's install directory, or the overridden mods path.
+	load_from_local = true,
+
 	# Overrides for the path mods/configs/workshop folders are loaded from.
 	# Only applied if custom settings are provided, either via the options.tres
 	# resource, or via CLI args. Note that CLI args can be tested in the editor

--- a/addons/mod_loader/resources/options_profile.gd
+++ b/addons/mod_loader/resources/options_profile.gd
@@ -1,9 +1,6 @@
 class_name ModLoaderOptionsProfile
 extends Resource
 
-# export (String) var my_string := ""
-# export (Resource) var upgrade_to_process_icon = null
-# export (Array, Resource) var elites: = []
 
 export (bool) var enable_mods = true
 export (Array, String) var locked_mods = []
@@ -11,6 +8,7 @@ export (ModLoaderLog.VERBOSITY_LEVEL) var log_level := ModLoaderLog.VERBOSITY_LE
 export (Array, String) var disabled_mods = []
 export (bool) var allow_modloader_autoloads_anywhere = false
 export (bool) var steam_workshop_enabled = false
+export (bool) var load_from_local = true
 export (String, DIR) var override_path_to_mods = ""
 export (String, DIR) var override_path_to_configs = ""
 export (String, DIR) var override_path_to_workshop = ""


### PR DESCRIPTION
- Added `load_from_local` option.
- `load_from_local` is true by default.
- Changed the if statement when loading mods to allow loading mods from multiple sources.
