### PR TITLE
Workaround for Script.get_script_method_list()

### DIFF
--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -136,8 +136,14 @@ func process_script(path: String, enable_hook_check := false, method_mask: Array
 		var is_async := is_func_async(func_body.get_string())
 		var can_return := can_return(source_code, method.name, closing_paren_index, func_body_start_index)
 		var method_arg_string_with_defaults_and_types := get_function_parameters(method.name, source_code, is_static)
-		var method_arg_string_names_only := get_function_arg_name_string(method.args)
-
+		# Workaround for Script.get_script_method_list() not working as intended for some scripts in Godot 4.1
+		var method_args_with_hints_and_defaults = Array(method_arg_string_with_defaults_and_types.split(", "))
+		var method_arg_string = ""
+		for method_arg_with_hint_and_default in method_args_with_hints_and_defaults:
+			var method_arg_with_hint = Array(method_arg_with_hint_and_default.split("=")).front()				# remove defaults
+			method_arg_string += Array(method_arg_with_hint.split(":")).front() + ", "							# remove hints
+		var method_arg_string_names_only := method_arg_string.substr(0,method_arg_string.length()-2) as String	# remove trailing comma
+		
 		var hook_id := _ModLoaderHooks.get_hook_hash(path, method.name)
 		var hook_id_data := [path, method.name, true]
 		if hashmap.has(hook_id):

--- a/addons/mod_loader/internal/mod_hook_preprocessor.gd
+++ b/addons/mod_loader/internal/mod_hook_preprocessor.gd
@@ -138,11 +138,7 @@ func process_script(path: String, enable_hook_check := false, method_mask: Array
 		var method_arg_string_with_defaults_and_types := get_function_parameters(method.name, source_code, is_static)
 		# Workaround for Script.get_script_method_list() not working as intended for some scripts in Godot 4.1
 		var method_args_with_hints_and_defaults = Array(method_arg_string_with_defaults_and_types.split(", "))
-		var method_arg_string = ""
-		for method_arg_with_hint_and_default in method_args_with_hints_and_defaults:
-			var method_arg_with_hint = Array(method_arg_with_hint_and_default.split("=")).front()				# remove defaults
-			method_arg_string += Array(method_arg_with_hint.split(":")).front() + ", "							# remove hints
-		var method_arg_string_names_only := method_arg_string.substr(0,method_arg_string.length()-2) as String	# remove trailing comma
+		var method_arg_string_names_only := get_function_arg_name_string(method_args_with_hints_and_defaults)
 		
 		var hook_id := _ModLoaderHooks.get_hook_hash(path, method.name)
 		var hook_id_data := [path, method.name, true]
@@ -261,15 +257,12 @@ func is_func_async(func_body_text: String) -> bool:
 	return false
 
 
-static func get_function_arg_name_string(args: Array) -> String:
-	var arg_string := ""
-	for x in args.size():
-		if x == args.size() -1:
-			arg_string += args[x].name
-		else:
-			arg_string += "%s, " % args[x].name
-
-	return arg_string
+static func get_function_arg_name_string(method_args_with_hints_and_defaults: Array) -> String:
+	var method_arg_string = ""
+	for method_arg_with_hint_and_default in method_args_with_hints_and_defaults:
+		var method_arg_with_hint = Array(method_arg_with_hint_and_default.split("=")).front()		# remove defaults
+		method_arg_string += Array(method_arg_with_hint.split(":")).front() + ", "					# remove hints
+	return method_arg_string.trim_suffix(", ")
 
 
 static func get_function_parameters(method_name: String, text: String, is_static: bool, offset := 0) -> String:


### PR DESCRIPTION
I discovered through the process of modding Buckshot Roulette (Godot 4.1.1) that `Script.get_script_method_list()` was not returning arguments for any of the functions in specific scripts (e.g. `MenuManager.gd`). This left `method.args` completely empty for every function parsed with `mod_hook_preprocessor.gd`. The current usage of this was easily replaceable with `method_arg_string_with_defaults_and_types`, which was just declared on the previous line.

This is a quick fix to get the mod loader working for Buckshot, and will likely need a little tweaking to fit in with the existing style.