### PR TITLE
Don't log error when a mod folder isn't found

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -193,10 +193,12 @@ static func get_zip_paths_in(folder_path: String) -> Array[String]:
 static func get_mod_paths_from_all_sources() -> Array[String]:
 	var mod_paths: Array[String] = []
 
-	var mod_dirs := get_dir_paths_in_dir(get_unpacked_mods_dir_path())
-
 	if ModLoaderStore.has_feature.editor or ModLoaderStore.ml_options.load_from_unpacked:
-		mod_paths.append_array(mod_dirs)
+		var unpacked_mod_dir := get_unpacked_mods_dir_path()
+		if not DirAccess.dir_exists_absolute(unpacked_mod_dir):
+			ModLoaderLog.info("The directory for mods at path \"%s\" does not exist." % unpacked_mod_dir, LOG_NAME)
+		else:
+			mod_paths.append_array(get_dir_paths_in_dir(unpacked_mod_dir))
 	else:
 		ModLoaderLog.info("Loading mods from \"res://mods-unpacked\" is disabled.", LOG_NAME)
 

--- a/addons/mod_loader/internal/third_party/steam.gd
+++ b/addons/mod_loader/internal/third_party/steam.gd
@@ -16,10 +16,11 @@ static func find_steam_workshop_zips() -> Array[String]:
 
 	ModLoaderLog.info("Checking workshop items, with path: \"%s\"" % workshop_folder_path, LOG_NAME)
 
-	var workshop_dir := DirAccess.open(workshop_folder_path)
-	if workshop_dir == null:
-		ModLoaderLog.error("Can't open workshop folder %s (Error: %s)" % [workshop_folder_path, error_string(DirAccess.get_open_error())], LOG_NAME)
+	if not DirAccess.dir_exists_absolute(workshop_folder_path):
+		ModLoaderLog.info("The directory for mods at path \"%s\" does not exist." % workshop_folder_path, LOG_NAME)
 		return []
+
+	var workshop_dir := DirAccess.open(workshop_folder_path)
 	var workshop_dir_listdir_error := workshop_dir.list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547
 	if not workshop_dir_listdir_error == OK:
 		ModLoaderLog.error("Can't read workshop folder %s (Error: %s)" % [workshop_folder_path, error_string(workshop_dir_listdir_error)], LOG_NAME)


### PR DESCRIPTION
Per default, the mod loader throws errors when the mods-unpacked folder or the Steam workshop folder isn't found.
However, on a clean install of a game without any mods installed, this is the expected setup.
Only once you download something from the Steam workshop or load a mod from some other source do these folders exist.
Now instead of reporting this configuration as an ERROR, its only an INFO resulting in a clean startup.

Before:
<img width="1166" height="127" alt="Screenshot_20260702_163839" src="https://github.com/user-attachments/assets/c7105250-5b40-4aba-9381-b252bbdfdece" />
After:
<img width="881" height="123" alt="image" src="https://github.com/user-attachments/assets/65f4e116-b260-43dc-b144-5c2fca0db194" />
